### PR TITLE
W5100 Driver

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,3 +3,4 @@ AllowShortLoopsOnASingleLine: true
 IndentCaseLabels: true
 UseTab: Never
 UseCRLF: false
+IndentWidth: 2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ add_executable(
   src/spi.c
   src/w5100.c
   src/utils.c
+  src/ethernet.c
 )
 
 # AVR Fuses

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ message(STATUS "Adding source files")
 add_executable(
   ${PROJECT_NAME}
   src/main.c
+  src/spi.c
 )
 
 # AVR Fuses

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,8 @@ add_executable(
   ${PROJECT_NAME}
   src/main.c
   src/spi.c
+  src/w5100.c
+  src/utils.c
 )
 
 # AVR Fuses
@@ -78,7 +80,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/config.h.in config.h @ONLY)
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${PROJECT_NAME}.elf)
 target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_include_directories(${PROJECT_NAME} PRIVATE "include")
-target_compile_options(${PROJECT_NAME} PRIVATE -mmcu=${MCU} -Wno-main -Wundef -Wstrict-prototypes -Werror -Wfatal-errors -gdwarf-2 -funsigned-char -funsigned-bitfields -fpack-struct -fshort-enums -fno-split-wide-types -fno-tree-scev-cprop)
+target_compile_options(${PROJECT_NAME} PRIVATE -mmcu=${MCU} -Wno-main -Wundef -Wstrict-prototypes -Wfatal-errors -gdwarf-2 -funsigned-char -funsigned-bitfields -fpack-struct -fshort-enums -fno-split-wide-types -fno-tree-scev-cprop)
 target_link_options(${PROJECT_NAME} PRIVATE -mmcu=${MCU} -u vfprintf -lprintf_flt -lm)
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE -DF_CPU=${F_CPU})

--- a/include/ethernet.h
+++ b/include/ethernet.h
@@ -1,0 +1,37 @@
+/**
+ * @file ethernet.h
+ * @brief 
+ * @version 0.1
+ * @date 2023-01
+ * 
+ * @copyright Copyright © 2023 dronectl
+ * 
+ */
+#ifndef __ETHERNET_H__
+#define __ETHERNET_H__
+
+#include <stdint.h>
+
+/**
+ * @brief IPv4 address representation types
+ * 
+ */
+typedef union ipv4_address_t {
+  uint8_t bytes[4]; // for byte data transactions
+  uint32_t dword; // for comparator ops
+} ipv4_address_t;
+
+void ethernet_init(void);
+void ethernet_set_gateway(const ipv4_address_t addr);
+void ethernet_get_gateway(ipv4_address_t *addr);
+void ethernet_set_subnet(const uint8_t *addr);
+void ethernet_get_subnet(uint8_t *addr);
+void ethernet_set_mac_addr(const uint8_t *addr);
+void ethernet_get_mac_addr(uint8_t *addr);
+void ethernet_set_ip_addr(const uint8_t *addr);
+void ethernet_get_ip_addr(uint8_t *addr);
+void ethernet_set_retransmit_time(uint16_t timeout);
+void ethernet_set_retransmit_count(uint8_t retry);
+void ethernet_reset(void);
+
+#endif // __ETHERNET_H__

--- a/include/ethernet.h
+++ b/include/ethernet.h
@@ -1,11 +1,11 @@
 /**
  * @file ethernet.h
- * @brief 
+ * @brief
  * @version 0.1
  * @date 2023-01
- * 
+ *
  * @copyright Copyright © 2023 dronectl
- * 
+ *
  */
 #ifndef __ETHERNET_H__
 #define __ETHERNET_H__
@@ -13,23 +13,31 @@
 #include <stdint.h>
 
 /**
+ * @brief Ethernet Proxy API Status Codes
+ *
+ */
+typedef uint8_t enet_status_t;
+#define ENET_OK (enet_status_t)0  // success code
+#define ENET_ERR (enet_status_t)1 // generic failure
+
+/**
  * @brief IPv4 address representation types
- * 
+ *
  */
 typedef union ipv4_address_t {
   uint8_t bytes[4]; // for byte data transactions
-  uint32_t dword; // for comparator ops
+  uint32_t dword;   // for comparator ops
 } ipv4_address_t;
 
-void ethernet_init(void);
-void ethernet_set_gateway(const ipv4_address_t addr);
-void ethernet_get_gateway(ipv4_address_t *addr);
-void ethernet_set_subnet(const uint8_t *addr);
-void ethernet_get_subnet(uint8_t *addr);
+enet_status_t ethernet_phy_init(void);
+void ethernet_set_gateway(const ipv4_address_t gateway);
+void ethernet_get_gateway(ipv4_address_t *gateway, uint16_t *len);
+void ethernet_set_subnet_mask(const ipv4_address_t subnet_mask);
+void ethernet_get_subnet_mask(ipv4_address_t *subnet_mask, uint16_t *len);
 void ethernet_set_mac_addr(const uint8_t *addr);
-void ethernet_get_mac_addr(uint8_t *addr);
-void ethernet_set_ip_addr(const uint8_t *addr);
-void ethernet_get_ip_addr(uint8_t *addr);
+void ethernet_get_mac_addr(uint8_t *addr, uint16_t *len);
+void ethernet_set_ip_addr(const ipv4_address_t ip_addr);
+void ethernet_get_ip_addr(ipv4_address_t *ip_addr, uint16_t *len);
 void ethernet_set_retransmit_time(uint16_t timeout);
 void ethernet_set_retransmit_count(uint8_t retry);
 void ethernet_reset(void);

--- a/include/spi.h
+++ b/include/spi.h
@@ -52,7 +52,6 @@ void spi_transact(uint8_t *buffer);
 uint8_t spi_transact_byte(const uint8_t buffer);
 void spi_enable_ss(void);
 void spi_disable_ss(void);
-
 void spi_end(void);
 
 #endif // __SPI_H__

--- a/include/spi.h
+++ b/include/spi.h
@@ -1,0 +1,54 @@
+/**
+ * @file spi.h
+ * @brief SPI definitions, constants and function declarations. Implementation
+ * is adapted from ArduinoCore-avr library:
+ * https://github.com/arduino/ArduinoCore-avr. This driver is written with
+ * minimal capabilities and does not include cross platform support preprocessor
+ * conditions.
+ * @version 0.1
+ * @date 2023-01
+ *
+ * @copyright Copyright © 2023 dronectl
+ *
+ */
+
+#ifndef __SPI_H__
+#define __SPI_H__
+
+#include <stdint.h>
+
+/**
+ * @brief SCK Phase x Polarity modes
+ * 18.4 Data Modes
+ */
+enum SPIMode {
+  SPI_MODE0 = 0x00, // Sample (rising), Setup (falling)
+  SPI_MODE1 = 0x04, // Setup (rising), Sample (falling)
+  SPI_MODE2 = 0x08, // Sample (falling), Setup (rising)
+  SPI_MODE3 = 0x0C, // Setup (falling), Sample (rising)
+};
+
+/**
+ * @brief Bit endianness
+ *
+ */
+enum Endian {
+  LITTLE_ENDIAN = 0x00, // LSB first
+  BIG_ENDIAN = 0x01,    // MSB first
+};
+
+/**
+ * @brief SPI init configuration
+ *
+ */
+typedef struct spi_config_t {
+  uint64_t clock;     // clock speed (Hz)
+  enum Endian endian; // bit order
+  enum SPIMode mode;  // data mode
+} spi_config_t;
+
+void spi_begin(spi_config_t spi_config);
+void spi_transact(uint8_t *buffer);
+void spi_end();
+
+#endif // __SPI_H__

--- a/include/spi.h
+++ b/include/spi.h
@@ -50,17 +50,8 @@ typedef struct spi_config_t {
 void spi_begin(spi_config_t spi_config);
 void spi_transact(uint8_t *buffer);
 uint8_t spi_transact_byte(const uint8_t buffer);
-
-/**
- * @brief Set SS low
- *
- */
-inline void spi_enable_ss(void) { PORTB &= ~(1 << PB2); }
-/**
- * @brief Reset SS high
- *
- */
-inline void spi_disable_ss(void) { PORTB |= (1 << PB2); }
+void spi_enable_ss(void);
+void spi_disable_ss(void);
 
 void spi_end(void);
 

--- a/include/spi.h
+++ b/include/spi.h
@@ -49,6 +49,19 @@ typedef struct spi_config_t {
 
 void spi_begin(spi_config_t spi_config);
 void spi_transact(uint8_t *buffer);
-void spi_end();
+uint8_t spi_transact_byte(const uint8_t buffer);
+
+/**
+ * @brief Set SS low
+ *
+ */
+inline void spi_enable_ss(void) { PORTB &= ~(1 << PB2); }
+/**
+ * @brief Reset SS high
+ *
+ */
+inline void spi_disable_ss(void) { PORTB |= (1 << PB2); }
+
+void spi_end(void);
 
 #endif // __SPI_H__

--- a/include/utils.h
+++ b/include/utils.h
@@ -1,0 +1,10 @@
+
+
+#ifndef __UTILS_H__
+#define __UTILS_H__
+
+#include <stdint.h>
+
+void delay_cycles(uint64_t cycles);
+
+#endif // __UTILS_H__

--- a/include/w5100.h
+++ b/include/w5100.h
@@ -1,7 +1,7 @@
 /**
  * @file w5100.h
  * @brief Functions declarations and definitions for interfacing with the w5100
- * ethernet controller.
+ * ethernet phy controller.
  * @version 0.1
  * @date 2023-01
  *
@@ -12,6 +12,7 @@
 #ifndef __W5100_H__
 #define __W5100_H__
 
+#include "spi.h"
 #include <avr/io.h>
 #include <stdint.h>
 
@@ -20,6 +21,18 @@
 #else
 #define W5100_MAX_SOCK_NUM 4
 #endif
+
+/**
+ * @brief W5100 API Status Codes
+ *
+ */
+typedef uint8_t w5100_status_t;
+#define W5100_OK (w5100_status_t)0  // success code
+#define W5100_ERR (w5100_status_t)1 // generic failure
+
+// static for multiple translation units
+static const spi_config_t w5100_spi_config = {
+    .clock = 14000000, .endian = BIG_ENDIAN, .mode = SPI_MODE0};
 
 /**
  * @brief Mode Register Bits
@@ -31,66 +44,79 @@
 #define MR_AI (uint8_t)(1 << 1)    // Address Auto-Increment in Indirect Bus I/F
 #define MR_IND (uint8_t)(1 << 0)   // Indirect Bus I/F mode
 
-#define __GP_REGISTER8(name, address)                                          \
-  static inline void write##name(uint8_t _data) {                              \
-    w5100_write_byte(address, _data);                                          \
+void _read_byte(uint16_t addr, uint8_t *buffer);
+void _write_byte(uint16_t addr, const uint8_t buffer);
+uint16_t _read_bytes(uint16_t addr, uint8_t *buffer, uint16_t len);
+uint16_t _write_bytes(uint16_t addr, const uint8_t *buffer, uint16_t len);
+
+/**
+ * @brief Common 8 bit register read and write functions
+ *
+ */
+#define __CREGISTER8(name, address)                                            \
+  static void w5100_write_##name(uint8_t _data) {                              \
+    _write_byte(address, _data);                                               \
   }                                                                            \
-  static inline uint8_t read##name(void) {                                     \
+  static uint8_t w5100_read_##name(void) {                                     \
     uint8_t data;                                                              \
-    w5100_read_byte(address, &data);                                           \
+    _read_byte(address, &data);                                                \
     return data;                                                               \
   }
 
-#define __GP_REGISTER16(name, address)                                         \
-  static uint16_t write##name(uint16_t _data) {                                \
+/**
+ * @brief Common 16 bit register read and write functions
+ *
+ */
+#define __CREGISTER16(name, address)                                           \
+  static uint16_t w5100_write_##name(const uint16_t _data) {                   \
     uint8_t buf[2];                                                            \
     buf[0] = _data >> 8;                                                       \
     buf[1] = _data & 0xFF;                                                     \
-    return w5100_write_bytes(address, buf, 2);                                 \
+    return _write_bytes(address, buf, 2);                                      \
   }                                                                            \
-  static uint16_t read##name(void) {                                           \
+  static uint16_t w5100_read_##name(void) {                                    \
     uint8_t buf[2];                                                            \
-    w5100_read_bytes(address, buf, 2);                                         \
+    read_bytes(address, buf, 2);                                               \
     return (buf[0] << 8) | buf[1];                                             \
   }
 
-#define __GP_REGISTER_N(name, address, size)                                   \
-  static uint16_t write##name(const uint8_t *_buffer) {                        \
-    return w5100_write_bytes(address, _buffer, size);                          \
+/**
+ * @brief Common N-bit register read and write functions
+ *
+ */
+#define __CREGISTER_N(name, address, size)                                     \
+  static uint16_t w5100_write_##name(const uint8_t *_buffer) {                 \
+    return _write_bytes(address, _buffer, size);                               \
   }                                                                            \
-  static uint16_t read##name(uint8_t *_buffer) {                               \
-    return w5100_read_bytes(address, _buffer, size);                           \
+  static uint16_t w5100_read_##name(uint8_t *_buffer) {                        \
+    return _read_bytes(address, _buffer, size);                                \
   }
 
-void w5100_read_byte(uint16_t addr, uint8_t *buffer);
-void w5100_write_byte(uint16_t addr, const uint8_t buffer);
-uint16_t w5100_read_bytes(uint16_t addr, uint8_t *buffer, uint16_t len);
-uint16_t w5100_write_bytes(uint16_t addr, const uint8_t *buffer, uint16_t len);
-void w5100_init(void);
-uint8_t w5100_soft_reset(void);
+w5100_status_t w5100_verify_hw(void);
+w5100_status_t w5100_reset(void);
 
 /**
  * @brief Common register definitions
  *
  * 4.1 Common Registers
  */
-__GP_REGISTER8(_mr, 0x0000)       // mode register
-__GP_REGISTER_N(_gar, 0x0001, 4)  // gateway address register
-__GP_REGISTER_N(_subr, 0x0005, 4) // subnet mask address register
-__GP_REGISTER_N(_shar, 0x0009, 6) // source hardware address register
-__GP_REGISTER_N(_sipr, 0x000F, 4) // source ip address register
-__GP_REGISTER8(_ir, 0x0015)       // interrupt register
-__GP_REGISTER8(_imr, 0x0016)      // interrupt mask register
-__GP_REGISTER16(_rtr, 0x0017)     // retry time-value register
-__GP_REGISTER8(_rcr, 0x0019)      // retry count register
-__GP_REGISTER8(_rmsr, 0x001A)     // rx memory size register
-__GP_REGISTER8(_tmsr, 0x001B)     // tx memory size register
-__GP_REGISTER8(_patr, 0x001C)     // authentication type in PPPoE mode
-__GP_REGISTER8(_ptimer,
-               0x0028) // PPP link control protocol request timer register
-__GP_REGISTER8(_pmagic,
-               0x0029) // PPP link control protocol magic number register
-__GP_REGISTER_N(_uipr, 0x002A, 4) // unreachable ip address register (UDP Mode)
-__GP_REGISTER16(_uport, 0x002E)   // unreachable port register (UDP Mode)
+__CREGISTER8(mr, 0x0000)      // mode register
+__CREGISTER_N(gar, 0x0001, 4) // gateway address register
+// __CREGISTER_N(subr, 0x0005, 4) // subnet mask address register
+// __CREGISTER_N(shar, 0x0009, 6) // source hardware address register
+// __CREGISTER_N(sipr, 0x000F, 4) // source ip address register
+// __CREGISTER8(ir, 0x0015)       // interrupt register
+// __CREGISTER8(imr, 0x0016)      // interrupt mask register
+// __CREGISTER_N(rtr, 0x0017, 2)  // retry time-value register
+// __CREGISTER8(rcr, 0x0019)      // retry count register
+// __CREGISTER8(rmsr, 0x001A)     // rx memory size register
+// __CREGISTER8(tmsr, 0x001B)     // tx memory size register
+// __CREGISTER8(patr, 0x001C)     // authentication type in PPPoE mode
+// __CREGISTER8(ptimer,
+//              0x0028) // PPP link control protocol request timer register
+// __CREGISTER8(pmagic,
+//              0x0029) // PPP link control protocol magic number register
+// __CREGISTER_N(uipr, 0x002A, 4)  // unreachable ip address register (UDP Mode)
+// __CREGISTER_N(uport, 0x002E, 2) // unreachable port register (UDP Mode)
 
 #endif // __W5100_H__

--- a/include/w5100.h
+++ b/include/w5100.h
@@ -100,11 +100,11 @@ w5100_status_t w5100_reset(void);
  *
  * 4.1 Common Registers
  */
-__CREGISTER8(mr, 0x0000)      // mode register
-__CREGISTER_N(gar, 0x0001, 4) // gateway address register
-// __CREGISTER_N(subr, 0x0005, 4) // subnet mask address register
-// __CREGISTER_N(shar, 0x0009, 6) // source hardware address register
-// __CREGISTER_N(sipr, 0x000F, 4) // source ip address register
+__CREGISTER8(mr, 0x0000)       // mode register
+__CREGISTER_N(gar, 0x0001, 4)  // gateway address register
+__CREGISTER_N(subr, 0x0005, 4) // subnet mask address register
+__CREGISTER_N(shar, 0x0009, 6) // source hardware address register
+__CREGISTER_N(sipr, 0x000F, 4) // source ip address register
 // __CREGISTER8(ir, 0x0015)       // interrupt register
 // __CREGISTER8(imr, 0x0016)      // interrupt mask register
 // __CREGISTER_N(rtr, 0x0017, 2)  // retry time-value register

--- a/include/w5100.h
+++ b/include/w5100.h
@@ -1,0 +1,88 @@
+/**
+ * @file w5100.h
+ * @brief Functions declarations and definitions for interfacing with the w5100
+ * ethernet controller.
+ * @version 0.1
+ * @date 2023-01
+ *
+ * @copyright Copyright © 2023 dronectl
+ *
+ */
+
+#ifndef __W5100_H__
+#define __W5100_H__
+
+#include <avr/io.h>
+#include <stdint.h>
+
+#if defined(RAMEND) && defined(RAMSTART) && ((RAMEND - RAMSTART) <= 1024)
+#define W5100_MAX_SOCK_NUM 2
+#else
+#define W5100_MAX_SOCK_NUM 4
+#endif
+
+#define MR_RST (uint8_t)(1 << 8)
+
+#define __GP_REGISTER8(name, address)                                          \
+  static inline void write##name(uint8_t _data) {                              \
+    w5100_write_byte(address, _data);                                          \
+  }                                                                            \
+  static inline uint8_t read##name(void) {                                     \
+    uint8_t data;                                                              \
+    w5100_read_byte(address, &data);                                           \
+    return data;                                                               \
+  }
+
+#define __GP_REGISTER16(name, address)                                         \
+  static uint16_t write##name(uint16_t _data) {                                \
+    uint8_t buf[2];                                                            \
+    buf[0] = _data >> 8;                                                       \
+    buf[1] = _data & 0xFF;                                                     \
+    return w5100_write_bytes(address, buf, 2);                                 \
+  }                                                                            \
+  static uint16_t read##name(void) {                                           \
+    uint8_t buf[2];                                                            \
+    w5100_read_bytes(address, buf, 2);                                         \
+    return (buf[0] << 8) | buf[1];                                             \
+  }
+
+#define __GP_REGISTER_N(name, address, size)                                   \
+  static uint16_t write##name(const uint8_t *_buffer) {                        \
+    return w5100_write_bytes(address, _buffer, size);                          \
+  }                                                                            \
+  static uint16_t read##name(uint8_t *_buffer) {                               \
+    return w5100_read_bytes(address, _buffer, size);                           \
+  }
+
+void w5100_read_byte(uint16_t addr, uint8_t *buffer);
+void w5100_write_byte(uint16_t addr, const uint8_t buffer);
+uint16_t w5100_read_bytes(uint16_t addr, uint8_t *buffer, uint16_t len);
+uint16_t w5100_write_bytes(uint16_t addr, const uint8_t *buffer, uint16_t len);
+void w5100_init(void);
+uint8_t w5100_soft_reset(void);
+
+/**
+ * @brief Common register definitions
+ *
+ * 4.1 Common Registers
+ */
+__GP_REGISTER8(_mr, 0x0000)       // mode register
+__GP_REGISTER_N(_gar, 0x0001, 4)  // gateway address register
+__GP_REGISTER_N(_subr, 0x0005, 4) // subnet mask address register
+__GP_REGISTER_N(_shar, 0x0009, 6) // source hardware address register
+__GP_REGISTER_N(_sipr, 0x000F, 4) // source ip address register
+__GP_REGISTER8(_ir, 0x0015)       // interrupt register
+__GP_REGISTER8(_imr, 0x0016)      // interrupt mask register
+__GP_REGISTER16(_rtr, 0x0017)     // retry time-value register
+__GP_REGISTER8(_rcr, 0x0019)      // retry count register
+__GP_REGISTER8(_rmsr, 0x001A)     // rx memory size register
+__GP_REGISTER8(_tmsr, 0x001B)     // tx memory size register
+__GP_REGISTER8(_patr, 0x001C)     // authentication type in PPPoE mode
+__GP_REGISTER8(_ptimer,
+               0x0028) // PPP link control protocol request timer register
+__GP_REGISTER8(_pmagic,
+               0x0029) // PPP link control protocol magic number register
+__GP_REGISTER_N(_uipr, 0x002A, 4) // unreachable ip address register (UDP Mode)
+__GP_REGISTER16(_uport, 0x002E)   // unreachable port register (UDP Mode)
+
+#endif // __W5100_H__

--- a/include/w5100.h
+++ b/include/w5100.h
@@ -21,7 +21,15 @@
 #define W5100_MAX_SOCK_NUM 4
 #endif
 
-#define MR_RST (uint8_t)(1 << 8)
+/**
+ * @brief Mode Register Bits
+ * 4.1 Common Registers
+ */
+#define MR_RST (uint8_t)(1 << 7)   // S/W Reset
+#define MR_PB (uint8_t)(1 << 4)    // Ping Block Mode
+#define MR_PPPOE (uint8_t)(1 << 3) // PPPoE Mode
+#define MR_AI (uint8_t)(1 << 1)    // Address Auto-Increment in Indirect Bus I/F
+#define MR_IND (uint8_t)(1 << 0)   // Indirect Bus I/F mode
 
 #define __GP_REGISTER8(name, address)                                          \
   static inline void write##name(uint8_t _data) {                              \

--- a/src/ethernet.c
+++ b/src/ethernet.c
@@ -1,0 +1,32 @@
+/**
+ * @file ethernet.c
+ * @brief
+ * @version 0.1
+ * @date 2023-01
+ *
+ * @copyright Copyright © 2023 dronectl
+ *
+ */
+
+#include "ethernet.h"
+#include "assert.h"
+#include "spi.h"
+#include "w5100.h"
+
+void ethernet_init(void) {
+  spi_begin(w5100_spi_config);
+  w5100_verify_hw();
+  spi_end();
+}
+
+void ethernet_set_gateway(const ipv4_address_t gateway) {
+  spi_begin(w5100_spi_config);
+  w5100_write_gar(gateway.bytes);
+  spi_end();
+}
+
+void ethernet_get_gateway(ipv4_address_t *gateway) {
+  spi_begin(w5100_spi_config);
+  w5100_read_gar(gateway->bytes);
+  spi_end();
+}

--- a/src/ethernet.c
+++ b/src/ethernet.c
@@ -13,20 +13,116 @@
 #include "spi.h"
 #include "w5100.h"
 
-void ethernet_init(void) {
+/**
+ * @brief Initialize ethernet phy chip.
+ *
+ */
+enet_status_t ethernet_phy_init(void) {
+  enet_status_t status = ENET_OK;
   spi_begin(w5100_spi_config);
-  w5100_verify_hw();
+  if (w5100_verify_hw() != W5100_OK)
+    status = ENET_ERR;
   spi_end();
+  return status;
 }
 
+/**
+ * @brief Write ethernet gateway to ethernet phy
+ *
+ * @param gateway gateway raw bytes
+ */
 void ethernet_set_gateway(const ipv4_address_t gateway) {
   spi_begin(w5100_spi_config);
   w5100_write_gar(gateway.bytes);
   spi_end();
 }
 
-void ethernet_get_gateway(ipv4_address_t *gateway) {
+/**
+ * @brief Query ethernet gateway from ethernet phy
+ *
+ * @param gateway ipv4_address_t pointer buffer
+ * @param len number of bytes read from transaction
+ */
+void ethernet_get_gateway(ipv4_address_t *gateway, uint16_t *len) {
+  assert(len != NULL);
+  assert(gateway != NULL);
   spi_begin(w5100_spi_config);
-  w5100_read_gar(gateway->bytes);
+  *len = w5100_read_gar(gateway->bytes);
+  spi_end();
+}
+
+/**
+ * @brief Write ethernet subnet mask to ethernet phy
+ *
+ * @param subnet_mask subnet mask raw bytes
+ */
+void ethernet_set_subnet_mask(const ipv4_address_t subnet_mask) {
+  spi_begin(w5100_spi_config);
+  w5100_write_subr(subnet_mask.bytes);
+  spi_end();
+}
+
+/**
+ * @brief Query ethernet subnet mask from ethernet phy
+ *
+ * @param subnet_mask ipv4_address_t pointer buffer
+ * @param len number of bytes read from transaction
+ */
+void ethernet_get_subnet_mask(ipv4_address_t *subnet_mask, uint16_t *len) {
+  assert(len != NULL);
+  assert(subnet_mask != NULL);
+  spi_begin(w5100_spi_config);
+  *len = w5100_read_subr(subnet_mask->bytes);
+  spi_end();
+}
+
+/**
+ * @brief Write ethernet ip address to ethernet phy
+ *
+ * @param ip_addr ip address raw bytes
+ */
+void ethernet_set_ip_addr(const ipv4_address_t ip_addr) {
+  spi_begin(w5100_spi_config);
+  w5100_write_sipr(ip_addr.bytes);
+  spi_end();
+}
+
+/**
+ * @brief Query ethernet ip address from ethernet phy
+ *
+ * @param ip_addr ipv4_address_t pointer buffer
+ * @param len number of bytes read from transaction
+ */
+void ethernet_get_ip_addr(ipv4_address_t *ip_addr, uint16_t *len) {
+  assert(len != NULL);
+  assert(ip_addr != NULL);
+  spi_begin(w5100_spi_config);
+  *len = w5100_read_sipr(ip_addr->bytes);
+  spi_end();
+}
+
+/**
+ * @brief Write ethernet mac address to ethernet phy
+ *
+ * @param mac_addr mac address raw bytes
+ */
+void ethernet_set_mac_addr(const uint8_t *mac_addr) {
+  assert(mac_addr != NULL);
+  spi_begin(w5100_spi_config);
+  w5100_write_sipr(mac_addr);
+  spi_end();
+}
+
+/**
+ * @brief Query ethernet mac address from ethernet phy
+ *
+ * @param mac_addr uint8_t pointer buffer
+ * @param len number of bytes read from transaction
+ */
+void ethernet_get_mac_addr(uint8_t *mac_addr, uint16_t *len) {
+  assert(len != NULL);
+  assert(mac_addr != NULL);
+  spi_begin(w5100_spi_config);
+  *len = w5100_read_sipr(mac_addr);
   spi_end();
 }

--- a/src/main.c
+++ b/src/main.c
@@ -9,9 +9,9 @@
  *
  */
 
+#include "ethernet.h"
 #include "spi.h"
 #include "utils.h"
-#include "w5100.h"
 #include <avr/cpufunc.h>
 #include <avr/io.h>
 
@@ -31,7 +31,11 @@ static void spinlock(void) {
 }
 
 int main(void) {
-  w5100_init();
+  ethernet_init();
+  ipv4_address_t gw;
+  gw.dword = 0xfefefefe;
+  ethernet_set_gateway(gw);
+  ethernet_get_gateway(&gw);
   spinlock();
   return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -9,11 +9,15 @@
  *
  */
 
+#include "spi.h"
 #include "utils.h"
+#include "w5100.h"
 #include <avr/cpufunc.h>
 #include <avr/io.h>
 
 static void spinlock(void) {
+  // status LED tied to SCK requires release of spi subsystem before use
+  spi_end();
   // Setup PB5 as Output high (source)
   PORTB = (1 << PB5);
   DDRB = (1 << DDB5);
@@ -27,6 +31,7 @@ static void spinlock(void) {
 }
 
 int main(void) {
+  w5100_init();
   spinlock();
   return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -31,11 +31,39 @@ static void spinlock(void) {
 }
 
 int main(void) {
-  ethernet_init();
+  uint16_t len;
+  // initialize phy
+  ethernet_phy_init();
   ipv4_address_t gw;
-  gw.dword = 0xfefefefe;
+  gw.bytes[0] = 192;
+  gw.bytes[1] = 168;
+  gw.bytes[2] = 2;
+  gw.bytes[3] = 1;
   ethernet_set_gateway(gw);
-  ethernet_get_gateway(&gw);
+  ethernet_get_gateway(&gw, &len);
+  ipv4_address_t mask;
+  mask.bytes[0] = 255;
+  mask.bytes[1] = 255;
+  mask.bytes[2] = 0;
+  mask.bytes[3] = 0;
+  ethernet_set_subnet_mask(mask);
+  ethernet_get_subnet_mask(&mask, &len);
+  ipv4_address_t ip_addr;
+  ip_addr.bytes[0] = 0;
+  ip_addr.bytes[1] = 0;
+  ip_addr.bytes[2] = 0;
+  ip_addr.bytes[3] = 0;
+  ethernet_set_ip_addr(ip_addr);
+  ethernet_get_gateway(&ip_addr, &len);
+  uint8_t mac_addr[6];
+  mac_addr[0] = 0xFE;
+  mac_addr[1] = 0xDC;
+  mac_addr[2] = 0xBA;
+  mac_addr[3] = 0x98;
+  mac_addr[4] = 0x76;
+  mac_addr[5] = 0x54;
+  ethernet_set_mac_addr((const uint8_t *)mac_addr);
+  ethernet_get_mac_addr(mac_addr, &len);
   spinlock();
   return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -9,14 +9,9 @@
  *
  */
 
+#include "utils.h"
 #include <avr/cpufunc.h>
 #include <avr/io.h>
-
-static void __delay(uint64_t cycles) {
-  for (uint64_t i = 0; i < cycles; i++) {
-    _NOP();
-  };
-}
 
 static void spinlock(void) {
   // Setup PB5 as Output high (source)
@@ -27,7 +22,7 @@ static void spinlock(void) {
   while (1) {
     // blink SCK
     PORTB ^= (1 << PORTB5);
-    __delay(100000);
+    delay_cycles(100000);
   }
 }
 

--- a/src/spi.c
+++ b/src/spi.c
@@ -1,0 +1,108 @@
+/**
+ * @file spi.c
+ * @brief
+ * @version 0.1
+ * @date 2023-01
+ *
+ * @copyright Copyright © 2023 dronectl
+ *
+ */
+#include <avr/cpufunc.h>
+#include <avr/interrupt.h>
+#include <avr/io.h>
+
+#include "config.h"
+#include "spi.h"
+
+/**
+ * @brief Register masks
+ *
+ */
+#define SPSR_SPI2X_MASK 0x01
+#define SPCR_SPI_MODE_MASK 0x0C
+#define SPCR_SPI_CLK_MASK 0x03
+
+/**
+ * @brief Setup SPI subsystem and gain access to SPI bus.
+ *
+ * @param spi_config spi bus configuration
+ */
+void spi_begin(spi_config_t spi_config) {
+  // clang-format off
+  /**
+   * @brief find the fastest clock rate less than or equal too the passed clock speed
+   * SPR1 SPR0 ~SPI2X
+   *  0    0     0    fosc/2
+   *  0    0     1    fosc/4
+   *  0    1     0    fosc/8
+   *  0    1     1    fosc/16
+   *  1    0     0    fosc/32
+   *  1    0     1    fosc/64 
+   *  1    1     0    fosc/64 << note duplicate mode
+   *  1    1     1    fosc/128
+   */
+  // clang-format on
+  // the clock divider is computed by 2 ^^ (clock_div + 1)
+  uint8_t clock_div = 7; // slowest speed 128 (default case) 6 + 1 compensates
+                         // for duplicate fosc64
+  if (spi_config.clock >= F_CPU / 2) {
+    clock_div = 0;
+  } else if (spi_config.clock >= F_CPU / 4) {
+    clock_div = 1;
+  } else if (spi_config.clock >= F_CPU / 8) {
+    clock_div = 2;
+  } else if (spi_config.clock >= F_CPU / 16) {
+    clock_div = 3;
+  } else if (spi_config.clock >= F_CPU / 32) {
+    clock_div = 4;
+  } else if (spi_config.clock >= F_CPU / 64) {
+    clock_div = 5;
+  }
+  // invert SPI2x bit
+  clock_div ^= 0x01;
+  uint8_t sreg = SREG;
+  cli();
+  // write SPI2X to status register
+  SPSR = (clock_div & SPSR_SPI2X_MASK);
+  // pack and write spi config control register
+  SPCR = (spi_config.endian == LITTLE_ENDIAN ? 1 : 0 << DORD) | (1 << SPE) |
+         (1 << MSTR) | (spi_config.mode & SPCR_SPI_MODE_MASK) |
+         (clock_div >> 1) & SPCR_SPI_CLK_MASK;
+  /**
+   * @brief Setup SPI pins. Doing this AFTER enabling SPI, avoids clocking in a
+   * single bit since the lines go directly from "input" to SPI control.
+   * PB5 -> SCK
+   * PB4 -> MISO (Configured as input automatically)
+   * PB3 -> MOSI
+   * PB2 -> SS (Slave select)
+   */
+  // set to high (source) internal pullup
+  PORTB = (1 << PB2);
+  // configure pins as outputs
+  DDRB = (1 << PB5) | (1 << PB3) | (1 << PB2);
+  SREG = sreg;
+}
+
+/**
+ * @brief Write buffer to SPI bus and receive data and copy into buffer
+ * TODO: enable capability to write array of instructions sequentially
+ * @param buffer pointer to single buffer element
+ */
+void spi_transact(uint8_t *buffer) {
+  SPDR = *buffer;
+  _NOP();
+  while (!(SPSR & (1 << SPIF))) _NOP();
+  *buffer = SPDR;
+}
+
+/**
+ * @brief Disable SPI subsystem.
+ *
+ */
+void spi_end() {
+  uint8_t sreg = SREG;
+  cli();
+  // disable spi
+  SPCR &= ~(1 << SPE);
+  SREG = sreg;
+}

--- a/src/spi.c
+++ b/src/spi.c
@@ -23,6 +23,17 @@
 #define SPCR_SPI_CLK_MASK 0x03
 
 /**
+ * @brief Set SS low
+ *
+ */
+void spi_enable_ss(void) { PORTB &= ~(1 << PB2); }
+/**
+ * @brief Reset SS high
+ *
+ */
+void spi_disable_ss(void) { PORTB |= (1 << PB2); }
+
+/**
  * @brief Setup SPI subsystem and gain access to SPI bus.
  *
  * @param spi_config spi bus configuration

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,0 +1,14 @@
+
+#include "utils.h"
+#include <avr/cpufunc.h>
+
+/**
+ * @brief
+ *
+ * @param cycles
+ */
+void delay_cycles(uint64_t cycles) {
+  for (uint64_t i = 0; i < cycles; i++) {
+    _NOP();
+  };
+}

--- a/src/w5100.c
+++ b/src/w5100.c
@@ -68,8 +68,12 @@ uint16_t w5100_read_bytes(uint16_t addr, uint8_t *buffer, uint16_t len) {
 }
 
 static uint8_t verify_w5100(void) {
-  write_mr(0x00);
-  return 0;
+  if (!w5100_soft_reset())
+    return 0;
+  write_mr(MR_PB);
+  if (read_mr() != MR_PB)
+    return 0;
+  return 1;
 }
 
 uint8_t w5100_soft_reset(void) {
@@ -91,5 +95,6 @@ void w5100_init(void) {
       .clock = 14000000, .endian = BIG_ENDIAN, .mode = SPI_MODE0};
   spi_begin(config);
   spi_disable_ss();
-  verify_w5100();
+  if (!verify_w5100())
+    return;
 }

--- a/src/w5100.c
+++ b/src/w5100.c
@@ -1,0 +1,95 @@
+/**
+ * @file w5100.c
+ * @brief
+ * @version 0.1
+ * @date 2023-01
+ *
+ * @copyright Copyright © 2023 dronectl
+ *
+ */
+
+#include "w5100.h"
+#include "spi.h"
+#include "utils.h"
+
+/**
+ * @brief Command opcodes for w5100
+ * 6.3.2 Commands
+ */
+#define WRITE_OPCODE 0xF0
+#define READ_OPCODE 0x0F
+
+/**
+ * @brief Write a byte to W5100 ethernet controller using SPI bus. SPI data
+ * bytes need to be written in 32-bit units in big endian format: OP-Code (1
+ * byte) -> Address (2 byte) -> Data (1 byte)
+ *
+ * @param addr W5100 register address
+ * @param buffer data byte
+ */
+void w5100_write_byte(uint16_t addr, const uint8_t buffer) {
+  spi_enable_ss();
+  spi_transact_byte(WRITE_OPCODE);
+  spi_transact_byte((addr >> 8)); // write address MSB first
+  spi_transact_byte((addr & 0xFF));
+  spi_transact_byte(buffer);
+  spi_disable_ss();
+}
+
+/**
+ * @brief Read a byte from the W5100 ethernet controller using SPI bus. SPI
+ * bytes need to be written in 32-bit units in big endian format: OP-Code (1
+ * byte) -> Address (2 byte) -> Data (1 byte)
+ *
+ * @param addr W5100 register address
+ * @param buffer byte data buffer
+ */
+void w5100_read_byte(uint16_t addr, uint8_t *buffer) {
+  spi_enable_ss();
+  spi_transact_byte(READ_OPCODE);
+  spi_transact_byte((addr >> 8)); // write address MSB first
+  spi_transact_byte((addr & 0xFF));
+  spi_transact(buffer);
+  spi_disable_ss();
+}
+
+uint16_t w5100_write_bytes(uint16_t addr, const uint8_t *buffer, uint16_t len) {
+  for (uint16_t i = 0; i < len; i++) {
+    w5100_write_byte(addr + i, buffer[i]);
+  }
+  return len;
+}
+
+uint16_t w5100_read_bytes(uint16_t addr, uint8_t *buffer, uint16_t len) {
+  for (uint16_t i = 0; i < len; i++) {
+    w5100_read_byte(addr + i, buffer + i);
+  }
+  return len;
+}
+
+static uint8_t verify_w5100(void) {
+  write_mr(0x00);
+  return 0;
+}
+
+uint8_t w5100_soft_reset(void) {
+  uint8_t counter = 0;
+  // write to mode register reset bit
+  write_mr(MR_RST);
+  // wait for soft reset to complete
+  do {
+    uint8_t mr = read_mr();
+    if (mr == 0x0)
+      return 1;
+    delay_cycles(1000);
+  } while (++counter < 20);
+  return 0;
+}
+
+void w5100_init(void) {
+  spi_config_t config = {
+      .clock = 14000000, .endian = BIG_ENDIAN, .mode = SPI_MODE0};
+  spi_begin(config);
+  spi_disable_ss();
+  verify_w5100();
+}


### PR DESCRIPTION
# Description
Implement basic IO utilities for interfacing with the w5100 chip in order to configure basic ethernet parameters:
1. MAC Address
2. Subnet Mask
3. Gateway
4. IP address

The w5100 driver implementation required development of a simple SPI driver in addition to a higher level ethernet proxy to start building out connectivity capabilities. Verification of firmware was done using a logic analyzer hooked up to the SPI bus. Below is an example of a software reset being issued to the W5100 device. The packet details are as follows:
 - WRITE Opcode 0xF0
 - ADDRESS 0x0000
 - Data 0x80 (RST bit toggled high)

![スクリーンショット 2023-01-13 1 15 39](https://user-images.githubusercontent.com/26971036/212503090-fcb73438-6978-4284-9757-7e445460e652.png)

## Resolutions
 - [x] Update clang formatting spec to specify indent width
 - [x] Develop SPI driver for ATMEGA328p
 - [x] Develop W5100 driver for Wiznet 
 - [x] Start implementation of ethernet proxy for providing ethernet connectivity to raptor device.

## Issues
closes #3 
closes #1 