### PR TITLE
W5100 Socket Driver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ add_executable(
   src/w5100.c
   src/utils.c
   src/ethernet.c
+  src/socket.c
   src/adc.c
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ add_executable(
   src/w5100.c
   src/utils.c
   src/ethernet.c
+  src/adc.c
 )
 
 # AVR Fuses

--- a/include/adc.h
+++ b/include/adc.h
@@ -13,8 +13,22 @@
 
 #include <stdint.h>
 
+enum ADCChannel {
+  ADC_CH0 = 0x0,
+  ADC_CH1 = 0x1,
+  ADC_CH2 = 0x2,
+  ADC_CH3 = 0x3,
+  ADC_CH4 = 0x4,
+  ADC_CH5 = 0x5,
+  ADC_CH6 = 0x6,
+  ADC_CH7 = 0x7,
+  ADC_CH8 = 0x8,
+  ADC_1V1 = 0xE,
+  ADC_GND = 0xF
+};
+
 void adc_init(void);
 void adc_shutdown(void);
-uint8_t adc_sample_lower(void);
+uint8_t adc_sample_lower(enum ADCChannel channel);
 
 #endif // __ADC_H__

--- a/include/adc.h
+++ b/include/adc.h
@@ -1,0 +1,20 @@
+/**
+ * @file adc.h
+ * @brief
+ * @version 0.1
+ * @date 2023-01
+ *
+ * @copyright Copyright © 2023 dronectl
+ *
+ */
+
+#ifndef __ADC_H__
+#define __ADC_H__
+
+#include <stdint.h>
+
+void adc_init(void);
+void adc_shutdown(void);
+uint8_t adc_sample_lower(void);
+
+#endif // __ADC_H__

--- a/include/ethernet.h
+++ b/include/ethernet.h
@@ -39,7 +39,6 @@ typedef struct enet_config_t {
 
 enet_status_t ethernet_phy_init(void);
 uint8_t ethernet_phy_state(void);
-w5100_mem_t *ethernet_phy_get_memmap(void);
 enet_status_t ethernet_configure(const enet_config_t *config);
 enet_status_t ethernet_set_gateway(const ipv4_address_t gateway);
 enet_status_t ethernet_get_gateway(ipv4_address_t *gateway, uint16_t *len);

--- a/include/ethernet.h
+++ b/include/ethernet.h
@@ -37,6 +37,7 @@ typedef struct enet_config_t {
 } enet_config_t;
 
 enet_status_t ethernet_phy_init(void);
+uint8_t ethernet_phy_state(void);
 enet_status_t ethernet_configure(const enet_config_t *config);
 void ethernet_reset(void);
 enet_status_t ethernet_set_gateway(const ipv4_address_t gateway);

--- a/include/ethernet.h
+++ b/include/ethernet.h
@@ -29,7 +29,15 @@ typedef union ipv4_address_t {
   uint32_t dword;   // for comparator ops
 } ipv4_address_t;
 
+typedef struct enet_config_t {
+  ipv4_address_t ip_addr;
+  ipv4_address_t subnet_mask;
+  ipv4_address_t gateway;
+} enet_config_t;
+
 enet_status_t ethernet_phy_init(void);
+enet_status_t ethernet_configure(const enet_config_t *config);
+void ethernet_reset(void);
 void ethernet_set_gateway(const ipv4_address_t gateway);
 void ethernet_get_gateway(ipv4_address_t *gateway, uint16_t *len);
 void ethernet_set_subnet_mask(const ipv4_address_t subnet_mask);
@@ -38,8 +46,7 @@ void ethernet_set_mac_addr(const uint8_t *addr);
 void ethernet_get_mac_addr(uint8_t *addr, uint16_t *len);
 void ethernet_set_ip_addr(const ipv4_address_t ip_addr);
 void ethernet_get_ip_addr(ipv4_address_t *ip_addr, uint16_t *len);
-void ethernet_set_retransmit_time(uint16_t timeout);
+void ethernet_set_retransmit_timeout(const uint8_t *ms);
 void ethernet_set_retransmit_count(uint8_t retry);
-void ethernet_reset(void);
 
 #endif // __ETHERNET_H__

--- a/include/ethernet.h
+++ b/include/ethernet.h
@@ -17,8 +17,9 @@
  *
  */
 typedef uint8_t enet_status_t;
-#define ENET_OK (enet_status_t)0  // success code
-#define ENET_ERR (enet_status_t)1 // generic failure
+#define ENET_OK (enet_status_t)0              // success code
+#define ENET_ERR (enet_status_t)1             // generic failure
+#define ENET_NOT_INITIALIZED (enet_status_t)2 // not initialized failure
 
 /**
  * @brief IPv4 address representation types
@@ -38,15 +39,16 @@ typedef struct enet_config_t {
 enet_status_t ethernet_phy_init(void);
 enet_status_t ethernet_configure(const enet_config_t *config);
 void ethernet_reset(void);
-void ethernet_set_gateway(const ipv4_address_t gateway);
-void ethernet_get_gateway(ipv4_address_t *gateway, uint16_t *len);
-void ethernet_set_subnet_mask(const ipv4_address_t subnet_mask);
-void ethernet_get_subnet_mask(ipv4_address_t *subnet_mask, uint16_t *len);
-void ethernet_set_mac_addr(const uint8_t *addr);
-void ethernet_get_mac_addr(uint8_t *addr, uint16_t *len);
-void ethernet_set_ip_addr(const ipv4_address_t ip_addr);
-void ethernet_get_ip_addr(ipv4_address_t *ip_addr, uint16_t *len);
-void ethernet_set_retransmit_timeout(const uint8_t *ms);
-void ethernet_set_retransmit_count(uint8_t retry);
+enet_status_t ethernet_set_gateway(const ipv4_address_t gateway);
+enet_status_t ethernet_get_gateway(ipv4_address_t *gateway, uint16_t *len);
+enet_status_t ethernet_set_subnet_mask(const ipv4_address_t subnet_mask);
+enet_status_t ethernet_get_subnet_mask(ipv4_address_t *subnet_mask,
+                                       uint16_t *len);
+enet_status_t ethernet_set_mac_addr(const uint8_t *addr);
+enet_status_t ethernet_get_mac_addr(uint8_t *addr, uint16_t *len);
+enet_status_t ethernet_set_ip_addr(const ipv4_address_t ip_addr);
+enet_status_t ethernet_get_ip_addr(ipv4_address_t *ip_addr, uint16_t *len);
+enet_status_t ethernet_set_retransmit_timeout(const uint8_t *ms);
+enet_status_t ethernet_set_retransmit_count(uint8_t retry);
 
 #endif // __ETHERNET_H__

--- a/include/ethernet.h
+++ b/include/ethernet.h
@@ -38,8 +38,8 @@ typedef struct enet_config_t {
 
 enet_status_t ethernet_phy_init(void);
 uint8_t ethernet_phy_state(void);
+w5100_mem_t *ethernet_phy_get_memmap(void);
 enet_status_t ethernet_configure(const enet_config_t *config);
-void ethernet_reset(void);
 enet_status_t ethernet_set_gateway(const ipv4_address_t gateway);
 enet_status_t ethernet_get_gateway(ipv4_address_t *gateway, uint16_t *len);
 enet_status_t ethernet_set_subnet_mask(const ipv4_address_t subnet_mask);
@@ -51,5 +51,6 @@ enet_status_t ethernet_set_ip_addr(const ipv4_address_t ip_addr);
 enet_status_t ethernet_get_ip_addr(ipv4_address_t *ip_addr, uint16_t *len);
 enet_status_t ethernet_set_retransmit_timeout(const uint8_t *ms);
 enet_status_t ethernet_set_retransmit_count(uint8_t retry);
+void ethernet_reset(void);
 
 #endif // __ETHERNET_H__

--- a/include/ethernet.h
+++ b/include/ethernet.h
@@ -10,6 +10,7 @@
 #ifndef __ETHERNET_H__
 #define __ETHERNET_H__
 
+#include "w5100.h"
 #include <stdint.h>
 
 /**

--- a/include/socket.h
+++ b/include/socket.h
@@ -39,5 +39,7 @@ socket_status_t socket_recv(enum W5100SCH channel, uint8_t *buffer,
                             uint16_t size);
 socket_status_t socket_get_unread_rx_bytes(enum W5100SCH channel);
 socket_status_t socket_peek(enum W5100SCH channel, uint8_t *buffer);
+socket_status_t socket_send(enum W5100SCH channel, const uint8_t *buffer,
+                            uint16_t len);
 
 #endif // __SOCKET_H__

--- a/include/socket.h
+++ b/include/socket.h
@@ -24,6 +24,9 @@ typedef uint8_t socket_status_t;
 #define SOCKET_OK (socket_status_t)0   // success code
 #define SOCKET_ERR (socket_status_t)1  // generic failure
 #define SOCKET_FULL (socket_status_t)2 // no available socket
+#define SOCKET_NO_DATA (socket_status_t)3 // no data available in RX buffer
+#define SOCKET_EOF (socket_status_t)4 // socket closed during operation
+#define SOCKET_UNINITIALIZED (socket_status_t)5  // socket uninitialized 
 
 socket_status_t socket_begin(enum W5100Proto protocol, uint16_t port,
                              enum W5100SCH *channel);
@@ -32,7 +35,7 @@ enum W5100State socket_get_status(enum W5100SCH channel);
 socket_status_t socket_connect(enum W5100SCH channel,
                                const ipv4_address_t *addr, uint16_t port);
 socket_status_t socket_disconnect(enum W5100SCH channel);
-
-socket_status_t socket_recv();
+socket_status_t socket_recv(enum W5100SCH channel, uint8_t *buffer, uint16_t size);
+socket_status_t socket_get_unread_rx_bytes(enum W5100SCH channel);
 
 #endif // __SOCKET_H__

--- a/include/socket.h
+++ b/include/socket.h
@@ -1,0 +1,34 @@
+/**
+ * @file socket.h
+ * @brief
+ * @version 0.1
+ * @date 2023-01
+ *
+ * @copyright Copyright © 2023 dronectl
+ *
+ */
+
+#ifndef __SOCKET_H__
+#define __SOCKET_H__
+
+#include "w5100.h"
+#include <stdint.h>
+
+/**
+ * @brief Ethernet Proxy API Status Codes
+ *
+ */
+typedef uint8_t socket_status_t;
+
+#define SOCKET_OK (socket_status_t)0   // success code
+#define SOCKET_ERR (socket_status_t)1  // generic failure
+#define SOCKET_FULL (socket_status_t)2 // no available socket
+
+socket_status_t socket_begin(uint8_t protocol, uint16_t port,
+                             enum W5100SCH *channel);
+socket_status_t socket_close(enum W5100SCH channel);
+socket_status_t socket_status(enum W5100SCH channel);
+socket_status_t socket_connect(enum W5100SCH channel);
+socket_status_t socket_disconnect(enum W5100SCH channel);
+
+#endif // __SOCKET_H__

--- a/include/socket.h
+++ b/include/socket.h
@@ -21,12 +21,12 @@
  */
 typedef uint8_t socket_status_t;
 
-#define SOCKET_OK (socket_status_t)0   // success code
-#define SOCKET_ERR (socket_status_t)1  // generic failure
-#define SOCKET_FULL (socket_status_t)2 // no available socket
+#define SOCKET_OK (socket_status_t)0      // success code
+#define SOCKET_ERR (socket_status_t)1     // generic failure
+#define SOCKET_FULL (socket_status_t)2    // no available socket
 #define SOCKET_NO_DATA (socket_status_t)3 // no data available in RX buffer
-#define SOCKET_EOF (socket_status_t)4 // socket closed during operation
-#define SOCKET_UNINITIALIZED (socket_status_t)5  // socket uninitialized 
+#define SOCKET_EOF (socket_status_t)4     // socket closed during operation
+#define SOCKET_UNINITIALIZED (socket_status_t)5 // socket uninitialized
 
 socket_status_t socket_begin(enum W5100Proto protocol, uint16_t port,
                              enum W5100SCH *channel);
@@ -35,7 +35,9 @@ enum W5100State socket_get_status(enum W5100SCH channel);
 socket_status_t socket_connect(enum W5100SCH channel,
                                const ipv4_address_t *addr, uint16_t port);
 socket_status_t socket_disconnect(enum W5100SCH channel);
-socket_status_t socket_recv(enum W5100SCH channel, uint8_t *buffer, uint16_t size);
+socket_status_t socket_recv(enum W5100SCH channel, uint8_t *buffer,
+                            uint16_t size);
 socket_status_t socket_get_unread_rx_bytes(enum W5100SCH channel);
+socket_status_t socket_peek(enum W5100SCH channel, uint8_t *buffer);
 
 #endif // __SOCKET_H__

--- a/include/socket.h
+++ b/include/socket.h
@@ -23,13 +23,13 @@ typedef uint8_t socket_status_t;
 
 #define SOCKET_OK (socket_status_t)0      // success code
 #define SOCKET_ERR (socket_status_t)1     // generic failure
-#define SOCKET_FULL (socket_status_t)2    // no available socket
+#define SOCKET_BUSY (socket_status_t)2    // requested socket is already active
 #define SOCKET_NO_DATA (socket_status_t)3 // no data available in RX buffer
 #define SOCKET_EOF (socket_status_t)4     // socket closed during operation
 #define SOCKET_UNINITIALIZED (socket_status_t)5 // socket uninitialized
 
-socket_status_t socket_begin(enum W5100Proto protocol, uint16_t port,
-                             enum W5100SCH *channel);
+socket_status_t socket_begin(enum W5100SCH channel, enum W5100Proto protocol,
+                             uint16_t port);
 socket_status_t socket_close(enum W5100SCH channel);
 enum W5100State socket_get_status(enum W5100SCH channel);
 socket_status_t socket_connect(enum W5100SCH channel,

--- a/include/socket.h
+++ b/include/socket.h
@@ -41,5 +41,10 @@ socket_status_t socket_get_unread_rx_bytes(enum W5100SCH channel);
 socket_status_t socket_peek(enum W5100SCH channel, uint8_t *buffer);
 socket_status_t socket_send(enum W5100SCH channel, const uint8_t *buffer,
                             uint16_t len);
-
+uint16_t socket_send_available(enum W5100SCH channel);
+socket_status_t socket_start_udp(enum W5100SCH channel,
+                                 const ipv4_address_t *addr, uint16_t port);
+socket_status_t socket_send_udp(enum W5100SCH channel);
+socket_status_t socket_buffer_data(enum W5100SCH channel, uint16_t offset,
+                                   const uint8_t *buffer, uint16_t len);
 #endif // __SOCKET_H__

--- a/include/socket.h
+++ b/include/socket.h
@@ -11,11 +11,12 @@
 #ifndef __SOCKET_H__
 #define __SOCKET_H__
 
+#include "ethernet.h"
 #include "w5100.h"
 #include <stdint.h>
 
 /**
- * @brief Ethernet Proxy API Status Codes
+ * @brief Socket API Status Codes
  *
  */
 typedef uint8_t socket_status_t;
@@ -24,11 +25,14 @@ typedef uint8_t socket_status_t;
 #define SOCKET_ERR (socket_status_t)1  // generic failure
 #define SOCKET_FULL (socket_status_t)2 // no available socket
 
-socket_status_t socket_begin(uint8_t protocol, uint16_t port,
+socket_status_t socket_begin(enum W5100Proto protocol, uint16_t port,
                              enum W5100SCH *channel);
 socket_status_t socket_close(enum W5100SCH channel);
-socket_status_t socket_status(enum W5100SCH channel);
-socket_status_t socket_connect(enum W5100SCH channel);
+enum W5100State socket_get_status(enum W5100SCH channel);
+socket_status_t socket_connect(enum W5100SCH channel,
+                               const ipv4_address_t *addr, uint16_t port);
 socket_status_t socket_disconnect(enum W5100SCH channel);
+
+socket_status_t socket_recv();
 
 #endif // __SOCKET_H__

--- a/include/utils.h
+++ b/include/utils.h
@@ -6,5 +6,6 @@
 #include <stdint.h>
 
 void delay_cycles(uint64_t cycles);
+uint8_t generate_random(void);
 
 #endif // __UTILS_H__

--- a/include/w5100.h
+++ b/include/w5100.h
@@ -135,10 +135,10 @@ enum W5100State {
   SNSR_ARP = 0x01
 };
 
-void _read_byte(uint16_t addr, uint8_t *buffer);
-void _write_byte(uint16_t addr, const uint8_t buffer);
-uint16_t _read_bytes(uint16_t addr, uint8_t *buffer, uint16_t len);
-uint16_t _write_bytes(uint16_t addr, const uint8_t *buffer, uint16_t len);
+void w5100_read_byte(uint16_t addr, uint8_t *buffer);
+void w5100_write_byte(uint16_t addr, const uint8_t buffer);
+uint16_t w5100_read_bytes(uint16_t addr, uint8_t *buffer, uint16_t len);
+uint16_t w5100_write_bytes(uint16_t addr, const uint8_t *buffer, uint16_t len);
 
 /**
  * @brief Common 8 bit register read and write functions
@@ -146,11 +146,11 @@ uint16_t _write_bytes(uint16_t addr, const uint8_t *buffer, uint16_t len);
  */
 #define __CREGISTER8(name, address)                                            \
   static void w5100_write_##name(const uint8_t _data) {                        \
-    _write_byte(address, _data);                                               \
+    w5100_write_byte(address, _data);                                          \
   }                                                                            \
   static uint8_t w5100_read_##name(void) {                                     \
     uint8_t data;                                                              \
-    _read_byte(address, &data);                                                \
+    w5100_read_byte(address, &data);                                           \
     return data;                                                               \
   }
 
@@ -160,10 +160,10 @@ uint16_t _write_bytes(uint16_t addr, const uint8_t *buffer, uint16_t len);
  */
 #define __CREGISTER_N(name, address, size)                                     \
   static uint16_t w5100_write_##name(const uint8_t *_buffer) {                 \
-    return _write_bytes(address, _buffer, size);                               \
+    return w5100_write_bytes(address, _buffer, size);                          \
   }                                                                            \
   static uint16_t w5100_read_##name(uint8_t *_buffer) {                        \
-    return _read_bytes(address, _buffer, size);                                \
+    return w5100_read_bytes(address, _buffer, size);                           \
   }
 
 /**
@@ -173,11 +173,11 @@ uint16_t _write_bytes(uint16_t addr, const uint8_t *buffer, uint16_t len);
 #define __SREGISTER8(name, address)                                            \
   static void w5100_write_sn_##name(const enum W5100SCH _s,                    \
                                     const uint8_t _data) {                     \
-    _write_byte(W5100_MEMAP_SREG_BASE(_s) + address, _data);                   \
+    w5100_write_byte(W5100_MEMAP_SREG_BASE(_s) + address, _data);              \
   }                                                                            \
   static uint8_t w5100_read_sn_##name(enum W5100SCH _s) {                      \
     uint8_t buffer;                                                            \
-    _read_byte(W5100_MEMAP_SREG_BASE(_s) + address, &buffer);                  \
+    w5100_read_byte(W5100_MEMAP_SREG_BASE(_s) + address, &buffer);             \
     return buffer;                                                             \
   }
 
@@ -188,13 +188,18 @@ uint16_t _write_bytes(uint16_t addr, const uint8_t *buffer, uint16_t len);
 #define __SREGISTER_N(name, address, size)                                     \
   static uint16_t w5100_write_sn_##name(const enum W5100SCH _s,                \
                                         const uint8_t *_buff) {                \
-    return _write_bytes(W5100_MEMAP_SREG_BASE(_s) + address, _buff, size);     \
+    return w5100_write_bytes(W5100_MEMAP_SREG_BASE(_s) + address, _buff,       \
+                             size);                                            \
   }                                                                            \
   static uint16_t w5100_read_sn_##name(enum W5100SCH _s, uint8_t *_buff) {     \
-    return _read_bytes(W5100_MEMAP_SREG_BASE(_s) + address, _buff, size);      \
+    return w5100_read_bytes(W5100_MEMAP_SREG_BASE(_s) + address, _buff, size); \
   }
 
-w5100_status_t w5100_configure(w5100_mem_t *sb);
+w5100_status_t w5100_configure();
+uint16_t w5100_get_tx_offset(enum W5100SCH _s);
+uint16_t w5100_get_rx_offset(enum W5100SCH _s);
+uint16_t w5100_get_tx_mask(enum W5100SCH _s);
+uint16_t w5100_get_rx_mask(enum W5100SCH _s);
 uint16_t w5100_read_tx_fsr(enum W5100SCH _s, uint16_t *_buff);
 uint16_t w5100_read_rx_rsr(enum W5100SCH _s, uint16_t *_buff);
 w5100_status_t w5100_verify_hw(void);

--- a/include/w5100.h
+++ b/include/w5100.h
@@ -67,7 +67,7 @@ static const spi_config_t w5100_spi_config = {
  * target sockets.
  *
  */
-enum W5100SockChannel { CH0 = 0, CH1 = 1, CH2 = 2, CH3 = 3 };
+enum W5100SCH { CH0 = 0, CH1 = 1, CH2 = 2, CH3 = 3 };
 
 enum W5100Proto {
   PROTO_CLOSED = 0x0,
@@ -156,11 +156,11 @@ uint16_t _write_bytes(uint16_t addr, const uint8_t *buffer, uint16_t len);
  *
  */
 #define __SREGISTER8(name, address)                                            \
-  static void w5100_write_sn_##name(const enum W5100SockChannel _s,            \
+  static void w5100_write_sn_##name(const enum W5100SCH _s,            \
                                     const uint8_t _data) {                     \
     _write_byte(W5100_MEMAP_SREG_BASE(_s), _data);                             \
   }                                                                            \
-  static uint8_t w5100_read_sn_##name(enum W5100SockChannel _s) {              \
+  static uint8_t w5100_read_sn_##name(enum W5100SCH _s) {              \
     uint8_t buffer;                                                            \
     _read_byte(W5100_MEMAP_SREG_BASE(_s), &buffer);                            \
     return buffer;                                                             \
@@ -171,17 +171,17 @@ uint16_t _write_bytes(uint16_t addr, const uint8_t *buffer, uint16_t len);
  *
  */
 #define __SREGISTER_N(name, address, size)                                     \
-  static uint16_t w5100_write_sn_##name(const enum W5100SockChannel _s,        \
+  static uint16_t w5100_write_sn_##name(const enum W5100SCH _s,        \
                                         const uint8_t *_buff) {                \
     return _write_bytes(W5100_MEMAP_SREG_BASE(_s), _buff, size);               \
   }                                                                            \
-  static uint16_t w5100_read_sn_##name(enum W5100SockChannel _s,               \
+  static uint16_t w5100_read_sn_##name(enum W5100SCH _s,               \
                                        uint8_t *_buff) {                       \
     return _read_bytes(W5100_MEMAP_SREG_BASE(_s), _buff, size);                \
   }
 
 w5100_status_t w5100_verify_hw(void);
-void w5100_exec_sock_cmd(const enum W5100SockChannel sock,
+void w5100_exec_sock_cmd(const enum W5100SCH sock,
                          const enum W5100SockCmds cmd);
 w5100_status_t w5100_reset(void);
 

--- a/include/w5100.h
+++ b/include/w5100.h
@@ -156,11 +156,11 @@ uint16_t _write_bytes(uint16_t addr, const uint8_t *buffer, uint16_t len);
  *
  */
 #define __SREGISTER8(name, address)                                            \
-  static void w5100_write_sn_##name(const enum W5100SCH _s,            \
+  static void w5100_write_sn_##name(const enum W5100SCH _s,                    \
                                     const uint8_t _data) {                     \
     _write_byte(W5100_MEMAP_SREG_BASE(_s), _data);                             \
   }                                                                            \
-  static uint8_t w5100_read_sn_##name(enum W5100SCH _s) {              \
+  static uint8_t w5100_read_sn_##name(enum W5100SCH _s) {                      \
     uint8_t buffer;                                                            \
     _read_byte(W5100_MEMAP_SREG_BASE(_s), &buffer);                            \
     return buffer;                                                             \
@@ -171,12 +171,11 @@ uint16_t _write_bytes(uint16_t addr, const uint8_t *buffer, uint16_t len);
  *
  */
 #define __SREGISTER_N(name, address, size)                                     \
-  static uint16_t w5100_write_sn_##name(const enum W5100SCH _s,        \
+  static uint16_t w5100_write_sn_##name(const enum W5100SCH _s,                \
                                         const uint8_t *_buff) {                \
     return _write_bytes(W5100_MEMAP_SREG_BASE(_s), _buff, size);               \
   }                                                                            \
-  static uint16_t w5100_read_sn_##name(enum W5100SCH _s,               \
-                                       uint8_t *_buff) {                       \
+  static uint16_t w5100_read_sn_##name(enum W5100SCH _s, uint8_t *_buff) {     \
     return _read_bytes(W5100_MEMAP_SREG_BASE(_s), _buff, size);                \
   }
 

--- a/include/w5100.h
+++ b/include/w5100.h
@@ -196,7 +196,7 @@ uint16_t w5100_write_bytes(uint16_t addr, const uint8_t *buffer, uint16_t len);
     return w5100_read_bytes(W5100_MEMAP_SREG_BASE(_s) + address, _buff, size); \
   }
 
-w5100_status_t w5100_configure();
+w5100_status_t w5100_configure(void);
 uint16_t w5100_get_tx_offset(enum W5100SCH _s);
 uint16_t w5100_get_rx_offset(enum W5100SCH _s);
 uint16_t w5100_get_tx_mask(enum W5100SCH _s);

--- a/include/w5100.h
+++ b/include/w5100.h
@@ -29,6 +29,11 @@
 #define W5100_MEMAP_SREG_BASE(n)                                               \
   (W5100_SOCK_BASE + (W5100_SOCK_REG_MEM_SIZE * n))
 
+#define W5100_RX_BUFFER_BASE (uint16_t)0x6000
+#define W5100_TX_BUFFER_BASE (uint16_t)0x4000
+// TX and RX buffer sizes are the same (bytes)
+#define W5100_SOCKET_BUFFER_SIZE (W5100_RX_MEM_BASE - W5100_TX_MEM_BASE)
+
 typedef struct socket_mem_t {
   uint16_t mask;
   uint16_t offset;

--- a/include/w5100.h
+++ b/include/w5100.h
@@ -130,7 +130,7 @@ uint16_t _write_bytes(uint16_t addr, const uint8_t *buffer, uint16_t len);
  *
  */
 #define __CREGISTER8(name, address)                                            \
-  static void w5100_write_##name(uint8_t _data) {                              \
+  static void w5100_write_##name(const uint8_t _data) {                        \
     _write_byte(address, _data);                                               \
   }                                                                            \
   static uint8_t w5100_read_##name(void) {                                     \
@@ -156,7 +156,8 @@ uint16_t _write_bytes(uint16_t addr, const uint8_t *buffer, uint16_t len);
  *
  */
 #define __SREGISTER8(name, address)                                            \
-  static void w5100_write_sn_##name(enum W5100SockChannel _s, uint8_t _data) { \
+  static void w5100_write_sn_##name(const enum W5100SockChannel _s,            \
+                                    const uint8_t _data) {                     \
     _write_byte(W5100_MEMAP_SREG_BASE(_s), _data);                             \
   }                                                                            \
   static uint8_t w5100_read_sn_##name(enum W5100SockChannel _s) {              \
@@ -170,8 +171,8 @@ uint16_t _write_bytes(uint16_t addr, const uint8_t *buffer, uint16_t len);
  *
  */
 #define __SREGISTER_N(name, address, size)                                     \
-  static uint16_t w5100_write_sn_##name(enum W5100SockChannel _s,              \
-                                        uint8_t *_buff) {                      \
+  static uint16_t w5100_write_sn_##name(const enum W5100SockChannel _s,        \
+                                        const uint8_t *_buff) {                \
     return _write_bytes(W5100_MEMAP_SREG_BASE(_s), _buff, size);               \
   }                                                                            \
   static uint16_t w5100_read_sn_##name(enum W5100SockChannel _s,               \
@@ -180,6 +181,8 @@ uint16_t _write_bytes(uint16_t addr, const uint8_t *buffer, uint16_t len);
   }
 
 w5100_status_t w5100_verify_hw(void);
+void w5100_exec_sock_cmd(const enum W5100SockChannel sock,
+                         const enum W5100SockCmds cmd);
 w5100_status_t w5100_reset(void);
 
 /**

--- a/include/w5100.h
+++ b/include/w5100.h
@@ -22,6 +22,13 @@
 #define W5100_MAX_SOCK_NUM 4
 #endif
 
+// W5100 socket register width in memory
+#define W5100_SOCK_REG_MEM_SIZE 0x100
+// W5100 base socket register address (Socket 0)
+#define W5100_SOCK_BASE 0x0400
+#define W5100_MEMAP_SREG_BASE(n)                                               \
+  (W5100_SOCK_BASE + (W5100_SOCK_REG_MEM_SIZE * n))
+
 /**
  * @brief W5100 API Status Codes
  *
@@ -44,6 +51,75 @@ static const spi_config_t w5100_spi_config = {
 #define MR_AI (uint8_t)(1 << 1)    // Address Auto-Increment in Indirect Bus I/F
 #define MR_IND (uint8_t)(1 << 0)   // Indirect Bus I/F mode
 
+/**
+ * @brief Socket N Interrupt Register
+ * 4.2 Socket Registers
+ */
+#define SNIR_SENDOK (uint8_t)(1 << 4)  // Set if send op completed
+#define SNIR_TIMEOUT (uint8_t)(1 << 3) // Set if timeout occurs
+#define SNIR_RECV (uint8_t)(1 << 2)    // Set when phy receives data
+// set when connection termination is requested or finished
+#define SNIR_DISCON (uint8_t)(1 << 1)
+#define SNIR_CON (uint8_t)(1 << 0) // set if connection established
+
+/**
+ * @brief Socket Channel numbers. Use this enum to perform transactions to
+ * target sockets.
+ *
+ */
+enum W5100SockChannel { CH0 = 0, CH1 = 1, CH2 = 2, CH3 = 3 };
+
+enum W5100Proto {
+  PROTO_CLOSED = 0x0,
+  PROTO_TCP = 0x1,
+  PROTO_UDP = 0x2,
+  PROTO_IPRAW = 0x3,
+  PROTO_MACRAW = 0x4,
+  PROTO_PPPOE = 0x5
+};
+
+enum W5100SockCmds {
+  SOCK_OPEN = 0x01,
+  // TCP Mode Only. Waits for connection request from remote peer (TCP Client).
+  SOCK_LISTEN = 0x02,
+  // TCP Mode Only. Sends connection request to remote peer (TCP Server).
+  SOCK_CONNECT = 0x04,
+  // TCP Mode Only. Sends connecion termination request.
+  SOCK_DISCON = 0x08,
+  SOCK_CLOSE = 0x10,
+  // Transmit data up to size of TX write pointer
+  SOCK_SEND = 0x20,
+  // UDP Mode only. Performs send operation without ARP and uses DHAR
+  SOCK_SEND_MAC = 0x21,
+  // TCP Mode Only. Check connection status by sending 1 byte.
+  SOCK_SEND_KEEP = 0x22,
+  SOCK_RECV = 0x40,
+};
+
+/**
+ * @brief Socket N Status Register States.
+ * Sn_SR (Socket n Status Register) [R] [0x0403, 0x0503, 0x0603, 0x0703] [0x00]
+ */
+enum W5100State {
+  // All connection resources are released.
+  SNSR_CLOSED = 0x00,
+  SNSR_INIT = 0x13,
+  SNSR_LISTEN = 0x14,
+  SNSR_ESTABLISHED = 0x17,
+  SNSR_CLOSE_WAIT = 0x1C,
+  SNSR_UDP = 0x22,
+  SNSR_IPRAW = 0x32,
+  SNSR_MACRAW = 0x42,
+  SNSR_PPPOE = 0x5F,
+  SNSR_SYNSENT = 0x15,
+  SNSR_SYNRECV = 0x16,
+  SNSR_FIN_WAIT = 0x18,
+  SNSR_CLOSING = 0x1A,
+  SNSR_TIME_WAIT = 0x1B,
+  SNSR_LAST_ACK = 0x1D,
+  SNSR_ARP = 0x01
+};
+
 void _read_byte(uint16_t addr, uint8_t *buffer);
 void _write_byte(uint16_t addr, const uint8_t buffer);
 uint16_t _read_bytes(uint16_t addr, uint8_t *buffer, uint16_t len);
@@ -64,23 +140,6 @@ uint16_t _write_bytes(uint16_t addr, const uint8_t *buffer, uint16_t len);
   }
 
 /**
- * @brief Common 16 bit register read and write functions
- *
- */
-#define __CREGISTER16(name, address)                                           \
-  static uint16_t w5100_write_##name(const uint16_t _data) {                   \
-    uint8_t buf[2];                                                            \
-    buf[0] = _data >> 8;                                                       \
-    buf[1] = _data & 0xFF;                                                     \
-    return _write_bytes(address, buf, 2);                                      \
-  }                                                                            \
-  static uint16_t w5100_read_##name(void) {                                    \
-    uint8_t buf[2];                                                            \
-    read_bytes(address, buf, 2);                                               \
-    return (buf[0] << 8) | buf[1];                                             \
-  }
-
-/**
  * @brief Common N-bit register read and write functions
  *
  */
@@ -90,6 +149,34 @@ uint16_t _write_bytes(uint16_t addr, const uint8_t *buffer, uint16_t len);
   }                                                                            \
   static uint16_t w5100_read_##name(uint8_t *_buffer) {                        \
     return _read_bytes(address, _buffer, size);                                \
+  }
+
+/**
+ * @brief Nth Socket 8 bit register read and write functions
+ *
+ */
+#define __SREGISTER8(name, address)                                            \
+  static void w5100_write_sn_##name(enum W5100SockChannel _s, uint8_t _data) { \
+    _write_byte(W5100_MEMAP_SREG_BASE(_s), _data);                             \
+  }                                                                            \
+  static uint8_t w5100_read_sn_##name(enum W5100SockChannel _s) {              \
+    uint8_t buffer;                                                            \
+    _read_byte(W5100_MEMAP_SREG_BASE(_s), &buffer);                            \
+    return buffer;                                                             \
+  }
+
+/**
+ * @brief Nth Socket N-bit register read and write functions
+ *
+ */
+#define __SREGISTER_N(name, address, size)                                     \
+  static uint16_t w5100_write_sn_##name(enum W5100SockChannel _s,              \
+                                        uint8_t *_buff) {                      \
+    return _write_bytes(W5100_MEMAP_SREG_BASE(_s), _buff, size);               \
+  }                                                                            \
+  static uint16_t w5100_read_sn_##name(enum W5100SockChannel _s,               \
+                                       uint8_t *_buff) {                       \
+    return _read_bytes(W5100_MEMAP_SREG_BASE(_s), _buff, size);                \
   }
 
 w5100_status_t w5100_verify_hw(void);
@@ -105,18 +192,44 @@ __CREGISTER_N(gar, 0x0001, 4)  // gateway address register
 __CREGISTER_N(subr, 0x0005, 4) // subnet mask address register
 __CREGISTER_N(shar, 0x0009, 6) // source hardware address register
 __CREGISTER_N(sipr, 0x000F, 4) // source ip address register
-// __CREGISTER8(ir, 0x0015)       // interrupt register
-// __CREGISTER8(imr, 0x0016)      // interrupt mask register
-// __CREGISTER_N(rtr, 0x0017, 2)  // retry time-value register
-// __CREGISTER8(rcr, 0x0019)      // retry count register
-// __CREGISTER8(rmsr, 0x001A)     // rx memory size register
-// __CREGISTER8(tmsr, 0x001B)     // tx memory size register
-// __CREGISTER8(patr, 0x001C)     // authentication type in PPPoE mode
-// __CREGISTER8(ptimer,
-//              0x0028) // PPP link control protocol request timer register
-// __CREGISTER8(pmagic,
-//              0x0029) // PPP link control protocol magic number register
-// __CREGISTER_N(uipr, 0x002A, 4)  // unreachable ip address register (UDP Mode)
-// __CREGISTER_N(uport, 0x002E, 2) // unreachable port register (UDP Mode)
+__CREGISTER8(ir, 0x0015)       // interrupt register
+__CREGISTER8(imr, 0x0016)      // interrupt mask register
+__CREGISTER_N(rtr, 0x0017, 2)  // retry time-value register
+__CREGISTER8(rcr, 0x0019)      // retry count register
+__CREGISTER8(rmsr, 0x001A)     // rx memory size register
+__CREGISTER8(tmsr, 0x001B)     // tx memory size register
+__CREGISTER8(patr, 0x001C)     // authentication type in PPPoE mode
+__CREGISTER8(ptimer,
+             0x0028) // PPP link control protocol request timer register
+__CREGISTER8(pmagic,
+             0x0029) // PPP link control protocol magic number register
+__CREGISTER_N(uipr, 0x002A, 4)  // unreachable ip address register (UDP Mode)
+__CREGISTER_N(uport, 0x002E, 2) // unreachable port register (UDP Mode)
+
+/**
+ * @brief Socket register definitions
+ *
+ * 4.2 Socket Registers
+ */
+__SREGISTER8(mr, 0x0000)         // Mode
+__SREGISTER8(cr, 0x0001)         // Command
+__SREGISTER8(ir, 0x0002)         // Interrupt
+__SREGISTER8(sr, 0x0003)         // Status
+__SREGISTER_N(port, 0x0004, 2)   // Source Port
+__SREGISTER_N(dhar, 0x0006, 6)   // Destination Hardw Addr
+__SREGISTER_N(dipr, 0x000C, 4)   // Destination IP Addr
+__SREGISTER_N(dport, 0x0010, 2)  // Destination Port
+__SREGISTER_N(mssr, 0x0012, 2)   // Max Segment Size
+__SREGISTER8(proto, 0x0014)      // Protocol in IP RAW Mode
+__SREGISTER8(tos, 0x0015)        // IP TOS
+__SREGISTER8(ttl, 0x0016)        // IP TTL
+__SREGISTER8(rx_size, 0x001E)    // RX Memory Size (W5200 only)
+__SREGISTER8(tx_size, 0x001F)    // RX Memory Size (W5200 only)
+__SREGISTER_N(tx_fsr, 0x0020, 2) // TX Free Size
+__SREGISTER_N(tx_rd, 0x0022, 2)  // TX Read Pointer
+__SREGISTER_N(tx_wr, 0x0024, 2)  // TX Write Pointer
+__SREGISTER_N(rx_rsr, 0x0026, 2) // RX Free Size
+__SREGISTER_N(rx_rd, 0x0028, 2)  // RX Read Pointer
+__SREGISTER_N(rx_wr, 0x002A, 2)  // RX Write Pointer (supported?)
 
 #endif // __W5100_H__

--- a/include/w5100.h
+++ b/include/w5100.h
@@ -36,7 +36,8 @@
 
 typedef struct socket_mem_t {
   uint16_t mask;
-  uint16_t offset;
+  uint16_t offset; // offset calculated from buffer base (bytes)
+  uint16_t size;   // socket memory size (bytes)
 } socket_mem_t;
 
 typedef struct w5100_mem_t {
@@ -200,6 +201,8 @@ uint16_t w5100_get_tx_offset(enum W5100SCH _s);
 uint16_t w5100_get_rx_offset(enum W5100SCH _s);
 uint16_t w5100_get_tx_mask(enum W5100SCH _s);
 uint16_t w5100_get_rx_mask(enum W5100SCH _s);
+uint16_t w5100_get_tx_size(enum W5100SCH _s);
+uint16_t w5100_get_rx_size(enum W5100SCH _s);
 uint16_t w5100_read_tx_fsr(enum W5100SCH _s, uint16_t *_buff);
 uint16_t w5100_read_rx_rsr(enum W5100SCH _s, uint16_t *_buff);
 w5100_status_t w5100_verify_hw(void);

--- a/include/w5100.h
+++ b/include/w5100.h
@@ -44,8 +44,6 @@ typedef struct w5100_mem_t {
   socket_mem_t rx_mem; // receive memory access fields
 } w5100_mem_t;
 
-w5100_mem_t socket_buffers[4];
-
 /**
  * @brief W5100 API Status Codes
  *
@@ -196,7 +194,7 @@ uint16_t _write_bytes(uint16_t addr, const uint8_t *buffer, uint16_t len);
     return _read_bytes(W5100_MEMAP_SREG_BASE(_s) + address, _buff, size);      \
   }
 
-w5100_status_t w5100_configure(void);
+w5100_status_t w5100_configure(w5100_mem_t *sb);
 uint16_t w5100_read_tx_fsr(enum W5100SCH _s, uint16_t *_buff);
 uint16_t w5100_read_rx_rsr(enum W5100SCH _s, uint16_t *_buff);
 w5100_status_t w5100_verify_hw(void);
@@ -209,6 +207,8 @@ w5100_status_t w5100_reset(void);
  *
  * 4.1 Common Registers
  */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
 __CREGISTER8(mr, 0x0000)       // mode register
 __CREGISTER_N(gar, 0x0001, 4)  // gateway address register
 __CREGISTER_N(subr, 0x0005, 4) // subnet mask address register
@@ -251,5 +251,6 @@ __SREGISTER_N(tx_rd, 0x0022, 2) // TX Read Pointer
 __SREGISTER_N(tx_wr, 0x0024, 2) // TX Write Pointer
 __SREGISTER_N(rx_rd, 0x0028, 2) // RX Read Pointer
 __SREGISTER_N(rx_wr, 0x002A, 2) // RX Write Pointer (supported?)
+#pragma GCC diagnostic pop
 
 #endif // __W5100_H__

--- a/include/w5100.h
+++ b/include/w5100.h
@@ -158,11 +158,11 @@ uint16_t _write_bytes(uint16_t addr, const uint8_t *buffer, uint16_t len);
 #define __SREGISTER8(name, address)                                            \
   static void w5100_write_sn_##name(const enum W5100SCH _s,                    \
                                     const uint8_t _data) {                     \
-    _write_byte(W5100_MEMAP_SREG_BASE(_s), _data);                             \
+    _write_byte(W5100_MEMAP_SREG_BASE(_s) + address, _data);                   \
   }                                                                            \
   static uint8_t w5100_read_sn_##name(enum W5100SCH _s) {                      \
     uint8_t buffer;                                                            \
-    _read_byte(W5100_MEMAP_SREG_BASE(_s), &buffer);                            \
+    _read_byte(W5100_MEMAP_SREG_BASE(_s) + address, &buffer);                  \
     return buffer;                                                             \
   }
 
@@ -173,10 +173,10 @@ uint16_t _write_bytes(uint16_t addr, const uint8_t *buffer, uint16_t len);
 #define __SREGISTER_N(name, address, size)                                     \
   static uint16_t w5100_write_sn_##name(const enum W5100SCH _s,                \
                                         const uint8_t *_buff) {                \
-    return _write_bytes(W5100_MEMAP_SREG_BASE(_s), _buff, size);               \
+    return _write_bytes(W5100_MEMAP_SREG_BASE(_s) + address, _buff, size);     \
   }                                                                            \
   static uint16_t w5100_read_sn_##name(enum W5100SCH _s, uint8_t *_buff) {     \
-    return _read_bytes(W5100_MEMAP_SREG_BASE(_s), _buff, size);                \
+    return _read_bytes(W5100_MEMAP_SREG_BASE(_s) + address, _buff, size);      \
   }
 
 w5100_status_t w5100_verify_hw(void);

--- a/include/w5100.h
+++ b/include/w5100.h
@@ -179,6 +179,8 @@ uint16_t _write_bytes(uint16_t addr, const uint8_t *buffer, uint16_t len);
     return _read_bytes(W5100_MEMAP_SREG_BASE(_s) + address, _buff, size);      \
   }
 
+uint16_t w5100_read_tx_fsr(enum W5100SCH _s, uint16_t *_buff);
+uint16_t w5100_read_rx_rsr(enum W5100SCH _s, uint16_t *_buff);
 w5100_status_t w5100_verify_hw(void);
 void w5100_exec_sock_cmd(const enum W5100SCH sock,
                          const enum W5100SockCmds cmd);
@@ -213,25 +215,23 @@ __CREGISTER_N(uport, 0x002E, 2) // unreachable port register (UDP Mode)
  *
  * 4.2 Socket Registers
  */
-__SREGISTER8(mr, 0x0000)         // Mode
-__SREGISTER8(cr, 0x0001)         // Command
-__SREGISTER8(ir, 0x0002)         // Interrupt
-__SREGISTER8(sr, 0x0003)         // Status
-__SREGISTER_N(port, 0x0004, 2)   // Source Port
-__SREGISTER_N(dhar, 0x0006, 6)   // Destination Hardw Addr
-__SREGISTER_N(dipr, 0x000C, 4)   // Destination IP Addr
-__SREGISTER_N(dport, 0x0010, 2)  // Destination Port
-__SREGISTER_N(mssr, 0x0012, 2)   // Max Segment Size
-__SREGISTER8(proto, 0x0014)      // Protocol in IP RAW Mode
-__SREGISTER8(tos, 0x0015)        // IP TOS
-__SREGISTER8(ttl, 0x0016)        // IP TTL
-__SREGISTER8(rx_size, 0x001E)    // RX Memory Size (W5200 only)
-__SREGISTER8(tx_size, 0x001F)    // RX Memory Size (W5200 only)
-__SREGISTER_N(tx_fsr, 0x0020, 2) // TX Free Size
-__SREGISTER_N(tx_rd, 0x0022, 2)  // TX Read Pointer
-__SREGISTER_N(tx_wr, 0x0024, 2)  // TX Write Pointer
-__SREGISTER_N(rx_rsr, 0x0026, 2) // RX Free Size
-__SREGISTER_N(rx_rd, 0x0028, 2)  // RX Read Pointer
-__SREGISTER_N(rx_wr, 0x002A, 2)  // RX Write Pointer (supported?)
+__SREGISTER8(mr, 0x0000)        // Mode
+__SREGISTER8(cr, 0x0001)        // Command
+__SREGISTER8(ir, 0x0002)        // Interrupt
+__SREGISTER8(sr, 0x0003)        // Status
+__SREGISTER_N(port, 0x0004, 2)  // Source Port
+__SREGISTER_N(dhar, 0x0006, 6)  // Destination Hardw Addr
+__SREGISTER_N(dipr, 0x000C, 4)  // Destination IP Addr
+__SREGISTER_N(dport, 0x0010, 2) // Destination Port
+__SREGISTER_N(mssr, 0x0012, 2)  // Max Segment Size
+__SREGISTER8(proto, 0x0014)     // Protocol in IP RAW Mode
+__SREGISTER8(tos, 0x0015)       // IP TOS
+__SREGISTER8(ttl, 0x0016)       // IP TTL
+__SREGISTER8(rx_size, 0x001E)   // RX Memory Size (W5200 only)
+__SREGISTER8(tx_size, 0x001F)   // RX Memory Size (W5200 only)
+__SREGISTER_N(tx_rd, 0x0022, 2) // TX Read Pointer
+__SREGISTER_N(tx_wr, 0x0024, 2) // TX Write Pointer
+__SREGISTER_N(rx_rd, 0x0028, 2) // RX Read Pointer
+__SREGISTER_N(rx_wr, 0x002A, 2) // RX Write Pointer (supported?)
 
 #endif // __W5100_H__

--- a/include/w5100.h
+++ b/include/w5100.h
@@ -29,6 +29,18 @@
 #define W5100_MEMAP_SREG_BASE(n)                                               \
   (W5100_SOCK_BASE + (W5100_SOCK_REG_MEM_SIZE * n))
 
+typedef struct socket_mem_t {
+  uint16_t mask;
+  uint16_t offset;
+} socket_mem_t;
+
+typedef struct w5100_mem_t {
+  socket_mem_t tx_mem; // transmission memory access fields
+  socket_mem_t rx_mem; // receive memory access fields
+} w5100_mem_t;
+
+w5100_mem_t socket_buffers[4];
+
 /**
  * @brief W5100 API Status Codes
  *
@@ -179,6 +191,7 @@ uint16_t _write_bytes(uint16_t addr, const uint8_t *buffer, uint16_t len);
     return _read_bytes(W5100_MEMAP_SREG_BASE(_s) + address, _buff, size);      \
   }
 
+w5100_status_t w5100_configure(void);
 uint16_t w5100_read_tx_fsr(enum W5100SCH _s, uint16_t *_buff);
 uint16_t w5100_read_rx_rsr(enum W5100SCH _s, uint16_t *_buff);
 w5100_status_t w5100_verify_hw(void);

--- a/src/adc.c
+++ b/src/adc.c
@@ -1,0 +1,44 @@
+/**
+ * @file adc.c
+ * @brief
+ * @version 0.1
+ * @date 2023-01
+ *
+ * @copyright Copyright © 2023 dronectl
+ *
+ */
+
+#include "adc.h"
+#include <avr/cpufunc.h>
+#include <avr/io.h>
+
+/**
+ * @brief Initialize ADC. For now use default settings.
+ *
+ */
+void adc_init(void) {
+  // startup the adc subsystem by disabling power reduction
+  PRR &= ~(1 << PRADC);
+  // enable adc
+  ADCSRA |= (1 << ADEN);
+}
+
+/**
+ * @brief for random number generation.
+ *
+ * @return uint8_t
+ */
+uint8_t adc_sample_lower(void) {
+  // start conversion manually
+  ADCSRA |= (1 << ADSC);
+  while (ADCSRA & (1 << ADSC)) {
+    _NOP();
+  }
+  return ADCL;
+}
+
+void adc_shutdown(void) {
+  // TODO: ensure conversion is not in progress
+  ADCSRA &= ~(1 << ADEN);
+  PRR |= (1 << PRADC);
+}

--- a/src/adc.c
+++ b/src/adc.c
@@ -31,7 +31,7 @@ void adc_init(void) {
 }
 
 /**
- * @brief for random number generation.
+ * @brief for random number generation. BUG: Sampling not working.
  *
  * @return uint8_t
  */

--- a/src/ethernet.c
+++ b/src/ethernet.c
@@ -13,9 +13,11 @@
 #include "spi.h"
 #include "utils.h"
 #include "w5100.h"
+#include <string.h>
 
 // ethernet phy initialized flag (used as guard check)
 static uint8_t phy_initialized = 0;
+static w5100_mem_t phy_buffer_memmap[4];
 
 static void generate_mac_address(uint8_t *mac_addr) {
   assert(mac_addr != NULL);
@@ -27,6 +29,8 @@ static void generate_mac_address(uint8_t *mac_addr) {
   mac_addr[0] |= 0x02;
 }
 
+w5100_mem_t *ethernet_phy_get_memmap(void) { return phy_buffer_memmap; }
+
 uint8_t ethernet_phy_state(void) { return phy_initialized; }
 
 /**
@@ -35,10 +39,15 @@ uint8_t ethernet_phy_state(void) { return phy_initialized; }
  */
 enet_status_t ethernet_phy_init(void) {
   enet_status_t status = ENET_OK;
+  w5100_mem_t memory[4];
   spi_begin(w5100_spi_config);
   if (w5100_verify_hw() != W5100_OK)
     status = ENET_ERR;
+  if (w5100_configure(&memory) != W5100_OK)
+    status = ENET_ERR;
   spi_end();
+  // set memory map
+  memcpy(phy_buffer_memmap, memory, sizeof(memory) * 4);
   // set initialization status
   phy_initialized = status == ENET_OK ? 1 : 0;
   return status;

--- a/src/ethernet.c
+++ b/src/ethernet.c
@@ -16,7 +16,6 @@
 
 // ethernet phy initialized flag (used as guard check)
 static uint8_t phy_initialized = 0;
-static w5100_mem_t phy_buffer_memmap[4];
 
 static void generate_mac_address(uint8_t *mac_addr) {
   assert(mac_addr != NULL);
@@ -27,8 +26,6 @@ static void generate_mac_address(uint8_t *mac_addr) {
   // address standard.
   mac_addr[0] |= 0x02;
 }
-
-w5100_mem_t *ethernet_phy_get_memmap(void) { return phy_buffer_memmap; }
 
 uint8_t ethernet_phy_state(void) { return phy_initialized; }
 
@@ -42,11 +39,9 @@ enet_status_t ethernet_phy_init(void) {
   spi_begin(w5100_spi_config);
   if (w5100_verify_hw() != W5100_OK)
     status = ENET_ERR;
-  if (w5100_configure(memory) != W5100_OK)
+  if (w5100_configure() != W5100_OK)
     status = ENET_ERR;
   spi_end();
-  // set memory map
-  memcpy(phy_buffer_memmap, memory, sizeof(memory) * 4);
   // set initialization status
   phy_initialized = status == ENET_OK ? 1 : 0;
   return status;

--- a/src/ethernet.c
+++ b/src/ethernet.c
@@ -109,7 +109,7 @@ void ethernet_get_ip_addr(ipv4_address_t *ip_addr, uint16_t *len) {
 void ethernet_set_mac_addr(const uint8_t *mac_addr) {
   assert(mac_addr != NULL);
   spi_begin(w5100_spi_config);
-  w5100_write_sipr(mac_addr);
+  w5100_write_shar(mac_addr);
   spi_end();
 }
 

--- a/src/ethernet.c
+++ b/src/ethernet.c
@@ -12,7 +12,6 @@
 #include "assert.h"
 #include "spi.h"
 #include "utils.h"
-#include "w5100.h"
 #include <string.h>
 
 // ethernet phy initialized flag (used as guard check)
@@ -43,7 +42,7 @@ enet_status_t ethernet_phy_init(void) {
   spi_begin(w5100_spi_config);
   if (w5100_verify_hw() != W5100_OK)
     status = ENET_ERR;
-  if (w5100_configure(&memory) != W5100_OK)
+  if (w5100_configure(memory) != W5100_OK)
     status = ENET_ERR;
   spi_end();
   // set memory map

--- a/src/ethernet.c
+++ b/src/ethernet.c
@@ -35,7 +35,6 @@ uint8_t ethernet_phy_state(void) { return phy_initialized; }
  */
 enet_status_t ethernet_phy_init(void) {
   enet_status_t status = ENET_OK;
-  w5100_mem_t memory[4];
   spi_begin(w5100_spi_config);
   if (w5100_verify_hw() != W5100_OK)
     status = ENET_ERR;

--- a/src/ethernet.c
+++ b/src/ethernet.c
@@ -14,6 +14,18 @@
 #include "utils.h"
 #include "w5100.h"
 
+// ethernet phy initialized flag (used as guard check)
+static uint8_t phy_initialized = 0;
+
+typedef struct socket_state_t {
+  uint16_t rx_rsr; // number of bytes received
+  uint16_t rx_rd;  // address to read
+  uint16_t tx_fsr; // free space ready for transmit
+  uint8_t rx_inc;  // rx_rd increment counter
+} socket_state_t;
+
+static socket_state_t socket_state[W5100_MAX_SOCK_NUM];
+
 static void generate_mac_address(uint8_t *mac_addr) {
   assert(mac_addr != NULL);
   for (int i = 0; i < 6; i++) {
@@ -34,6 +46,8 @@ enet_status_t ethernet_phy_init(void) {
   if (w5100_verify_hw() != W5100_OK)
     status = ENET_ERR;
   spi_end();
+  // set initialization status
+  phy_initialized = status == ENET_OK ? 1 : 0;
   return status;
 }
 
@@ -45,6 +59,9 @@ enet_status_t ethernet_phy_init(void) {
  */
 enet_status_t ethernet_configure(const enet_config_t *config) {
   uint8_t mac_addr[6];
+  if (!phy_initialized) {
+    return ENET_NOT_INITIALIZED;
+  }
   // generate locally administered mac address
   generate_mac_address(mac_addr);
   // set phy properties
@@ -56,14 +73,68 @@ enet_status_t ethernet_configure(const enet_config_t *config) {
 }
 
 /**
+ * @brief Find an available socket to configure with target protocol and source
+ * port.
+ *
+ * @param protocol
+ * @param port
+ * @return uint8_t
+ */
+uint8_t ethernet_socket_begin(uint8_t protocol, uint16_t port) {
+  uint8_t sock_idx;
+  enum W5100State socket_status[W5100_MAX_SOCK_NUM];
+  if (!phy_initialized) {
+    return W5100_MAX_SOCK_NUM;
+  }
+  // find an unused socket and attempt to provision first available
+  spi_begin(w5100_spi_config);
+  for (sock_idx = 0; sock_idx < W5100_MAX_SOCK_NUM; sock_idx++) {
+    socket_status[sock_idx] = (enum W5100State)w5100_read_sn_sr(sock_idx);
+    if (socket_status[sock_idx] == SNSR_CLOSED)
+      goto make;
+  }
+  // attempt to forcibly close socket in closing state
+  for (sock_idx = 0; sock_idx < W5100_MAX_SOCK_NUM; sock_idx++) {
+    if (socket_status[sock_idx] == SNSR_LAST_ACK)
+      goto closemake;
+    if (socket_status[sock_idx] == SNSR_TIME_WAIT)
+      goto closemake;
+    if (socket_status[sock_idx] == SNSR_FIN_WAIT)
+      goto closemake;
+    if (socket_status[sock_idx] == SNSR_CLOSING)
+      goto closemake;
+  }
+  spi_end();
+  // failed to provision socket
+  return W5100_MAX_SOCK_NUM;
+closemake:
+  w5100_exec_sock_cmd(sock_idx, SOCK_CLOSE);
+make:
+  w5100_write_sn_mr(sock_idx, protocol);
+  w5100_write_sn_ir(sock_idx, 0xFF); // clear interrupt register
+  w5100_write_sn_port(sock_idx, (const uint8_t *)&port);
+  socket_state[sock_idx].rx_inc = 0;
+  socket_state[sock_idx].rx_rd = 0;
+  socket_state[sock_idx].rx_rsr = 0;
+  socket_state[sock_idx].tx_fsr = 0;
+  spi_end();
+  return sock_idx;
+}
+
+/**
  * @brief Write ethernet gateway to ethernet phy
  *
  * @param gateway gateway raw bytes
+ * @return enet_status_t
  */
-void ethernet_set_gateway(const ipv4_address_t gateway) {
+enet_status_t ethernet_set_gateway(const ipv4_address_t gateway) {
+  if (!phy_initialized) {
+    return ENET_NOT_INITIALIZED;
+  }
   spi_begin(w5100_spi_config);
   w5100_write_gar(gateway.bytes);
   spi_end();
+  return ENET_OK;
 }
 
 /**
@@ -71,24 +142,34 @@ void ethernet_set_gateway(const ipv4_address_t gateway) {
  *
  * @param gateway ipv4_address_t pointer buffer
  * @param len number of bytes read from transaction
+ * @return enet_status_t
  */
-void ethernet_get_gateway(ipv4_address_t *gateway, uint16_t *len) {
+enet_status_t ethernet_get_gateway(ipv4_address_t *gateway, uint16_t *len) {
   assert(len != NULL);
   assert(gateway != NULL);
+  if (!phy_initialized) {
+    return ENET_NOT_INITIALIZED;
+  }
   spi_begin(w5100_spi_config);
   *len = w5100_read_gar(gateway->bytes);
   spi_end();
+  return ENET_OK;
 }
 
 /**
  * @brief Write ethernet subnet mask to ethernet phy
  *
  * @param subnet_mask subnet mask raw bytes
+ * @return enet_status_t
  */
-void ethernet_set_subnet_mask(const ipv4_address_t subnet_mask) {
+enet_status_t ethernet_set_subnet_mask(const ipv4_address_t subnet_mask) {
+  if (!phy_initialized) {
+    return ENET_NOT_INITIALIZED;
+  }
   spi_begin(w5100_spi_config);
   w5100_write_subr(subnet_mask.bytes);
   spi_end();
+  return ENET_OK;
 }
 
 /**
@@ -96,24 +177,35 @@ void ethernet_set_subnet_mask(const ipv4_address_t subnet_mask) {
  *
  * @param subnet_mask ipv4_address_t pointer buffer
  * @param len number of bytes read from transaction
+ * @return enet_status_t
  */
-void ethernet_get_subnet_mask(ipv4_address_t *subnet_mask, uint16_t *len) {
+enet_status_t ethernet_get_subnet_mask(ipv4_address_t *subnet_mask,
+                                       uint16_t *len) {
   assert(len != NULL);
   assert(subnet_mask != NULL);
+  if (!phy_initialized) {
+    return ENET_NOT_INITIALIZED;
+  }
   spi_begin(w5100_spi_config);
   *len = w5100_read_subr(subnet_mask->bytes);
   spi_end();
+  return ENET_OK;
 }
 
 /**
  * @brief Write ethernet ip address to ethernet phy
  *
  * @param ip_addr ip address raw bytes
+ * @return enet_status_t
  */
-void ethernet_set_ip_addr(const ipv4_address_t ip_addr) {
+enet_status_t ethernet_set_ip_addr(const ipv4_address_t ip_addr) {
+  if (!phy_initialized) {
+    return ENET_NOT_INITIALIZED;
+  }
   spi_begin(w5100_spi_config);
   w5100_write_sipr(ip_addr.bytes);
   spi_end();
+  return ENET_OK;
 }
 
 /**
@@ -121,25 +213,35 @@ void ethernet_set_ip_addr(const ipv4_address_t ip_addr) {
  *
  * @param ip_addr ipv4_address_t pointer buffer
  * @param len number of bytes read from transaction
+ * @return enet_status_t
  */
-void ethernet_get_ip_addr(ipv4_address_t *ip_addr, uint16_t *len) {
+enet_status_t ethernet_get_ip_addr(ipv4_address_t *ip_addr, uint16_t *len) {
   assert(len != NULL);
   assert(ip_addr != NULL);
+  if (!phy_initialized) {
+    return ENET_NOT_INITIALIZED;
+  }
   spi_begin(w5100_spi_config);
   *len = w5100_read_sipr(ip_addr->bytes);
   spi_end();
+  return ENET_OK;
 }
 
 /**
  * @brief Write ethernet mac address to ethernet phy
  *
  * @param mac_addr mac address raw bytes
+ * @return enet_status_t
  */
-void ethernet_set_mac_addr(const uint8_t *mac_addr) {
+enet_status_t ethernet_set_mac_addr(const uint8_t *mac_addr) {
   assert(mac_addr != NULL);
+  if (!phy_initialized) {
+    return ENET_NOT_INITIALIZED;
+  }
   spi_begin(w5100_spi_config);
   w5100_write_shar(mac_addr);
   spi_end();
+  return ENET_OK;
 }
 
 /**
@@ -147,36 +249,51 @@ void ethernet_set_mac_addr(const uint8_t *mac_addr) {
  *
  * @param mac_addr uint8_t pointer buffer
  * @param len number of bytes read from transaction
+ * @return enet_status_t
  */
-void ethernet_get_mac_addr(uint8_t *mac_addr, uint16_t *len) {
+enet_status_t ethernet_get_mac_addr(uint8_t *mac_addr, uint16_t *len) {
   assert(len != NULL);
   assert(mac_addr != NULL);
+  if (!phy_initialized) {
+    return ENET_NOT_INITIALIZED;
+  }
   spi_begin(w5100_spi_config);
   *len = w5100_read_shar(mac_addr);
   spi_end();
+  return ENET_OK;
 }
 
 /**
  * @brief Set ethernet phy retransmission timeout time (ms)
  *
  * @param ms retransmission timeout (ms)
+ * @return enet_status_t
  */
-void ethernet_set_retransmit_timeout(const uint8_t *ms) {
+enet_status_t ethernet_set_retransmit_timeout(const uint8_t *ms) {
   assert(ms != NULL);
+  if (!phy_initialized) {
+    return ENET_NOT_INITIALIZED;
+  }
   spi_begin(w5100_spi_config);
   w5100_write_rtr(ms);
   spi_end();
+  return ENET_OK;
 }
 
 /**
  * @brief Set ethernet phy retransmission counter
  *
  * @param retry retry count
+ * @return enet_status_t
  */
-void ethernet_set_retransmit_count(uint8_t retry) {
+enet_status_t ethernet_set_retransmit_count(uint8_t retry) {
+  if (!phy_initialized) {
+    return ENET_NOT_INITIALIZED;
+  }
   spi_begin(w5100_spi_config);
   w5100_write_rcr(retry);
   spi_end();
+  return ENET_OK;
 }
 
 /**
@@ -185,6 +302,9 @@ void ethernet_set_retransmit_count(uint8_t retry) {
  */
 void ethernet_reset(void) {
   spi_begin(w5100_spi_config);
-  w5100_reset();
+  // reset phy init flag on successful reset
+  if (w5100_reset() == W5100_OK) {
+    phy_initialized = 0;
+  }
   spi_end();
 }

--- a/src/ethernet.c
+++ b/src/ethernet.c
@@ -123,6 +123,39 @@ void ethernet_get_mac_addr(uint8_t *mac_addr, uint16_t *len) {
   assert(len != NULL);
   assert(mac_addr != NULL);
   spi_begin(w5100_spi_config);
-  *len = w5100_read_sipr(mac_addr);
+  *len = w5100_read_shar(mac_addr);
+  spi_end();
+}
+
+/**
+ * @brief Set ethernet phy retransmission timeout time (ms)
+ *
+ * @param ms retransmission timeout (ms)
+ */
+void ethernet_set_retransmit_timeout(const uint8_t *ms) {
+  assert(ms != NULL);
+  spi_begin(w5100_spi_config);
+  w5100_write_rtr(ms);
+  spi_end();
+}
+
+/**
+ * @brief Set ethernet phy retransmission counter
+ *
+ * @param retry retry count
+ */
+void ethernet_set_retransmit_count(uint8_t retry) {
+  spi_begin(w5100_spi_config);
+  w5100_write_rcr(retry);
+  spi_end();
+}
+
+/**
+ * @brief Reset ethernet phy
+ *
+ */
+void ethernet_reset(void) {
+  spi_begin(w5100_spi_config);
+  w5100_reset();
   spi_end();
 }

--- a/src/ethernet.c
+++ b/src/ethernet.c
@@ -11,7 +11,18 @@
 #include "ethernet.h"
 #include "assert.h"
 #include "spi.h"
+#include "utils.h"
 #include "w5100.h"
+
+static void generate_mac_address(uint8_t *mac_addr) {
+  assert(mac_addr != NULL);
+  for (int i = 0; i < 6; i++) {
+    mac_addr[i] = generate_random() % 0xFF;
+  }
+  // set mac address to locally administered (NIC set by MFN). See IEEE 802 MAC
+  // address standard.
+  mac_addr[0] |= 0x02;
+}
 
 /**
  * @brief Initialize ethernet phy chip.
@@ -24,6 +35,24 @@ enet_status_t ethernet_phy_init(void) {
     status = ENET_ERR;
   spi_end();
   return status;
+}
+
+/**
+ * @brief Configure device ethernet phy
+ *
+ * @param config ethernet parameters
+ * @return enet_status_t
+ */
+enet_status_t ethernet_configure(const enet_config_t *config) {
+  uint8_t mac_addr[6];
+  // generate locally administered mac address
+  generate_mac_address(mac_addr);
+  // set phy properties
+  ethernet_set_gateway(config->gateway);
+  ethernet_set_subnet_mask(config->subnet_mask);
+  ethernet_set_ip_addr(config->ip_addr);
+  ethernet_set_mac_addr(mac_addr);
+  return ENET_OK;
 }
 
 /**

--- a/src/main.c
+++ b/src/main.c
@@ -39,31 +39,19 @@ int main(void) {
   gw.bytes[1] = 168;
   gw.bytes[2] = 2;
   gw.bytes[3] = 1;
-  ethernet_set_gateway(gw);
-  ethernet_get_gateway(&gw, &len);
   ipv4_address_t mask;
   mask.bytes[0] = 255;
   mask.bytes[1] = 255;
   mask.bytes[2] = 0;
   mask.bytes[3] = 0;
-  ethernet_set_subnet_mask(mask);
-  ethernet_get_subnet_mask(&mask, &len);
   ipv4_address_t ip_addr;
   ip_addr.bytes[0] = 0;
   ip_addr.bytes[1] = 0;
   ip_addr.bytes[2] = 0;
   ip_addr.bytes[3] = 0;
-  ethernet_set_ip_addr(ip_addr);
-  ethernet_get_gateway(&ip_addr, &len);
-  uint8_t mac_addr[6];
-  mac_addr[0] = 0xFE;
-  mac_addr[1] = 0xDC;
-  mac_addr[2] = 0xBA;
-  mac_addr[3] = 0x98;
-  mac_addr[4] = 0x76;
-  mac_addr[5] = 0x54;
-  ethernet_set_mac_addr((const uint8_t *)mac_addr);
-  ethernet_get_mac_addr(mac_addr, &len);
+  enet_config_t configuration = {
+      .gateway = gw, .subnet_mask = mask, .ip_addr = ip_addr};
+  ethernet_configure(&configuration);
   spinlock();
   return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -31,7 +31,6 @@ static void spinlock(void) {
 }
 
 int main(void) {
-  uint16_t len;
   // initialize phy
   ethernet_phy_init();
   ipv4_address_t gw;

--- a/src/socket.c
+++ b/src/socket.c
@@ -10,7 +10,6 @@
 
 #include "socket.h"
 #include "assert.h"
-#include "ethernet.h"
 
 typedef struct socket_state_t {
   uint16_t rx_rsr; // number of bytes received
@@ -29,7 +28,7 @@ static socket_state_t socket_state[W5100_MAX_SOCK_NUM];
  * @param port
  * @return uint8_t
  */
-socket_status_t socket_begin(uint8_t protocol, uint16_t port,
+socket_status_t socket_begin(enum W5100Proto protocol, uint16_t port,
                              enum W5100SCH *channel) {
   uint8_t sock_idx;
   enum W5100State socket_status[W5100_MAX_SOCK_NUM];
@@ -63,13 +62,105 @@ socket_status_t socket_begin(uint8_t protocol, uint16_t port,
 closemake:
   w5100_exec_sock_cmd(sock_idx, SOCK_CLOSE);
 make:
-  w5100_write_sn_mr(sock_idx, protocol);
+  w5100_write_sn_mr(sock_idx, (const uint8_t)protocol);
   w5100_write_sn_ir(sock_idx, 0xFF); // clear interrupt register
   w5100_write_sn_port(sock_idx, (const uint8_t *)&port);
+  w5100_exec_sock_cmd(sock_idx, SOCK_OPEN);
   socket_state[sock_idx].rx_inc = 0;
   socket_state[sock_idx].rx_rd = 0;
   socket_state[sock_idx].rx_rsr = 0;
   socket_state[sock_idx].tx_fsr = 0;
   spi_end();
   return sock_idx;
+}
+
+/**
+ * @brief Close target socket
+ *
+ * @param channel target socket
+ * @return socket_status_t
+ */
+socket_status_t socket_close(enum W5100SCH channel) {
+  if (!ethernet_phy_state()) {
+    return SOCKET_ERR;
+  }
+  spi_begin(w5100_spi_config);
+  w5100_exec_sock_cmd(channel, SOCK_CLOSE);
+  spi_end();
+  return SOCKET_OK;
+}
+
+/**
+ * @brief Set socket to listen (server) mode. Socket must be INIT state to
+ * transition to LISTEN.
+ *
+ * @param channel target socket
+ * @return socket_status_t
+ */
+socket_status_t socket_listen(enum W5100SCH channel) {
+  if (!ethernet_phy_state()) {
+    return SOCKET_ERR;
+  }
+  // socket must be init state to transistion to listen
+  if (socket_get_status(channel) != SNSR_INIT) {
+    return SOCKET_ERR;
+  }
+  spi_begin(w5100_spi_config);
+  w5100_exec_sock_cmd(channel, SOCK_LISTEN);
+  spi_end();
+  return SOCKET_OK;
+}
+
+/**
+ * @brief Get state of target socket
+ *
+ * @param channel target socket
+ * @return enum W5100State
+ */
+enum W5100State socket_get_status(enum W5100SCH channel) {
+  if (!ethernet_phy_state()) {
+    return SOCKET_ERR;
+  }
+  spi_begin(w5100_spi_config);
+  enum W5100State state = (enum W5100State)w5100_read_sn_sr(channel);
+  spi_end();
+  return state;
+}
+
+/**
+ * @brief Connect target socket. Establish a TCP connection in active (client)
+ * mode
+ *
+ * @param channel target socket
+ * @param addr destination ip address
+ * @param port destination port
+ * @return socket_status_t
+ */
+socket_status_t socket_connect(enum W5100SCH channel,
+                               const ipv4_address_t *addr, uint16_t port) {
+  if (!ethernet_phy_state()) {
+    return SOCKET_ERR;
+  }
+  spi_begin(w5100_spi_config);
+  w5100_write_sn_dipr(channel, addr->bytes);
+  w5100_write_sn_dport(channel, (const uint8_t *)&port);
+  w5100_exec_sock_cmd(channel, SOCK_CONNECT);
+  spi_end();
+  return SOCKET_OK;
+}
+
+/**
+ * @brief Disconnect target socket
+ *
+ * @param channel target socket
+ * @return socket_status_t
+ */
+socket_status_t socket_disconnect(enum W5100SCH channel) {
+  if (!ethernet_phy_state()) {
+    return SOCKET_ERR;
+  }
+  spi_begin(w5100_spi_config);
+  w5100_exec_sock_cmd(channel, SOCK_DISCON);
+  spi_end();
+  return SOCKET_OK;
 }

--- a/src/socket.c
+++ b/src/socket.c
@@ -255,4 +255,5 @@ socket_status_t socket_peek(enum W5100SCH channel, uint8_t *buffer) {
   assert(buffer != NULL);
   spi_begin(w5100_spi_config);
   spi_end();
+  return ENET_OK;
 }

--- a/src/socket.c
+++ b/src/socket.c
@@ -247,3 +247,12 @@ socket_status_t socket_get_unread_rx_bytes(enum W5100SCH channel) {
   }
   return rx_buf_size;
 }
+
+socket_status_t socket_peek(enum W5100SCH channel, uint8_t *buffer) {
+  if (!ethernet_phy_state()) {
+    return SOCKET_UNINITIALIZED;
+  }
+  assert(buffer != NULL);
+  spi_begin(w5100_spi_config);
+  spi_end();
+}

--- a/src/socket.c
+++ b/src/socket.c
@@ -110,6 +110,8 @@ socket_status_t socket_begin(enum W5100SCH channel, enum W5100Proto protocol,
       goto closemake;
     case SNSR_CLOSING:
       goto closemake;
+    default:
+      return SOCKET_ERR;
   }
   spi_end();
   // failed to provision socket
@@ -291,7 +293,7 @@ socket_status_t socket_recv(enum W5100SCH channel, uint8_t *buffer,
     // receive step complete set socket to SOCK_RECV and reset increment
     socket_state[channel].rx_inc = 0;
     // move socket read pointer
-    w5100_write_sn_rx_rd(channel, socket_state[channel].rx_rd);
+    w5100_write_sn_rx_rd(channel, (uint8_t *)socket_state[channel].rx_rd);
     w5100_exec_sock_cmd(channel, SOCK_RECV);
   } else {
     socket_state[channel].rx_inc = inc;
@@ -382,7 +384,7 @@ socket_status_t socket_send(enum W5100SCH channel, const uint8_t *buffer,
   } while (freesize < len);
 
   // write data
-  write_data(channel, 0, buffer, len);
+  send_data(channel, 0, buffer, len);
   w5100_exec_sock_cmd(channel, SOCK_SEND);
 
   // read interrupt register to verify send operation completion

--- a/src/socket.c
+++ b/src/socket.c
@@ -1,0 +1,75 @@
+/**
+ * @file socket.c
+ * @brief
+ * @version 0.1
+ * @date 2023-01
+ *
+ * @copyright Copyright © 2023 dronectl
+ *
+ */
+
+#include "socket.h"
+#include "assert.h"
+#include "ethernet.h"
+
+typedef struct socket_state_t {
+  uint16_t rx_rsr; // number of bytes received
+  uint16_t rx_rd;  // address to read
+  uint16_t tx_fsr; // free space ready for transmit
+  uint8_t rx_inc;  // rx_rd increment counter
+} socket_state_t;
+
+static socket_state_t socket_state[W5100_MAX_SOCK_NUM];
+
+/**
+ * @brief Find an available socket to configure with target protocol and source
+ * port.
+ *
+ * @param protocol
+ * @param port
+ * @return uint8_t
+ */
+socket_status_t socket_begin(uint8_t protocol, uint16_t port,
+                             enum W5100SCH *channel) {
+  uint8_t sock_idx;
+  enum W5100State socket_status[W5100_MAX_SOCK_NUM];
+  assert(channel != NULL);
+  if (!ethernet_phy_state()) {
+    *channel = W5100_MAX_SOCK_NUM;
+    return SOCKET_ERR;
+  }
+  // find an unused socket and attempt to provision first available
+  spi_begin(w5100_spi_config);
+  for (sock_idx = 0; sock_idx < W5100_MAX_SOCK_NUM; sock_idx++) {
+    socket_status[sock_idx] = (enum W5100State)w5100_read_sn_sr(sock_idx);
+    if (socket_status[sock_idx] == SNSR_CLOSED)
+      goto make;
+  }
+  // attempt to forcibly close socket in closing state
+  for (sock_idx = 0; sock_idx < W5100_MAX_SOCK_NUM; sock_idx++) {
+    if (socket_status[sock_idx] == SNSR_LAST_ACK)
+      goto closemake;
+    if (socket_status[sock_idx] == SNSR_TIME_WAIT)
+      goto closemake;
+    if (socket_status[sock_idx] == SNSR_FIN_WAIT)
+      goto closemake;
+    if (socket_status[sock_idx] == SNSR_CLOSING)
+      goto closemake;
+  }
+  spi_end();
+  // failed to provision socket
+  *channel = W5100_MAX_SOCK_NUM;
+  return SOCKET_FULL;
+closemake:
+  w5100_exec_sock_cmd(sock_idx, SOCK_CLOSE);
+make:
+  w5100_write_sn_mr(sock_idx, protocol);
+  w5100_write_sn_ir(sock_idx, 0xFF); // clear interrupt register
+  w5100_write_sn_port(sock_idx, (const uint8_t *)&port);
+  socket_state[sock_idx].rx_inc = 0;
+  socket_state[sock_idx].rx_rd = 0;
+  socket_state[sock_idx].rx_rsr = 0;
+  socket_state[sock_idx].tx_fsr = 0;
+  spi_end();
+  return sock_idx;
+}

--- a/src/utils.c
+++ b/src/utils.c
@@ -24,7 +24,7 @@ void delay_cycles(uint64_t cycles) {
 uint8_t generate_random(void) {
   adc_init();
   delay_cycles(51);
-  uint8_t rand = adc_sample_lower();
+  uint8_t rand = adc_sample_lower(ADC_CH1);
   adc_shutdown();
   return rand;
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -17,7 +17,7 @@ void delay_cycles(uint64_t cycles) {
 /**
  * @brief Generate a random number by sampling the ADC.
  * NOTE: This should only be used at program startup to avoid interfering with
- * ADC operation
+ * ADC operation.
  *
  * @return uint8_t randomly generated number
  */

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,5 +1,6 @@
 
 #include "utils.h"
+#include "adc.h"
 #include <avr/cpufunc.h>
 
 /**
@@ -11,4 +12,19 @@ void delay_cycles(uint64_t cycles) {
   for (uint64_t i = 0; i < cycles; i++) {
     _NOP();
   };
+}
+
+/**
+ * @brief Generate a random number by sampling the ADC.
+ * NOTE: This should only be used at program startup to avoid interfering with
+ * ADC operation
+ *
+ * @return uint8_t randomly generated number
+ */
+uint8_t generate_random(void) {
+  adc_init();
+  delay_cycles(51);
+  uint8_t rand = adc_sample_lower();
+  adc_shutdown();
+  return rand;
 }

--- a/src/w5100.c
+++ b/src/w5100.c
@@ -86,7 +86,7 @@ void w5100_read_byte(uint16_t addr, uint8_t *buffer) {
  *
  * @return w5100_status_t
  */
-w5100_status_t w5100_configure() {
+w5100_status_t w5100_configure(void) {
   // set RMSR
   spi_begin(w5100_spi_config);
   // config bit ordering [ 7 6 ] [ 5 4 ] [ 3]

--- a/src/w5100.c
+++ b/src/w5100.c
@@ -102,7 +102,7 @@ w5100_status_t w5100_reset(void) {
   return W5100_ERR;
 }
 
-void w5100_exec_sock_cmd(const enum W5100SockChannel sock,
+void w5100_exec_sock_cmd(const enum W5100SCH sock,
                          const enum W5100SockCmds cmd) {
   w5100_write_sn_cr(sock, cmd);
   // after command completion SnCR will autoclear

--- a/src/w5100.c
+++ b/src/w5100.c
@@ -79,12 +79,23 @@ w5100_status_t w5100_configure(void) {
   size_config = (6 << MEMSIZE_CONF_1024) | (4 << MEMSIZE_CONF_1024) |
                 (2 << MEMSIZE_CONF_4096) | (MEMSIZE_CONF_2048);
   w5100_write_tmsr(size_config);
-  // set socket tx and rx memory mask and basec
-  socket_buffers[1].rx_mem.mask = 0x0;
-  socket_buffers[2].rx_mem.mask = 0x0;
-  socket_buffers[3].rx_mem.mask = 0x0;
-  socket_buffers[4].rx_mem.mask = 0x0;
   spi_end();
+  // set socket tx and rx memory mask and base
+  uint16_t rx_alloc_sizes[4] = {0x800, 0x400, 0x1000, 0x400};
+  uint16_t tx_alloc_sizes[4] = {0x800, 0x1000, 0x400, 0x400};
+  for (int i = 0; i <= 3; i++) {
+    if (i == 0) {
+      socket_buffers[i].rx_mem.offset = W5100_RX_BUFFER_BASE;
+      socket_buffers[i].tx_mem.offset = W5100_TX_BUFFER_BASE;
+    } else {
+      socket_buffers[i].rx_mem.offset = socket_buffers[i - 1].rx_mem.offset +
+                                        socket_buffers[i - 1].rx_mem.mask + 0x1;
+      socket_buffers[i].tx_mem.offset = socket_buffers[i - 1].tx_mem.offset +
+                                        socket_buffers[i - 1].tx_mem.mask + 0x1;
+    }
+    socket_buffers[i].rx_mem.mask = rx_alloc_sizes[i] - 0x1;
+    socket_buffers[i].tx_mem.mask = tx_alloc_sizes[i] - 0x1;
+  }
   return W5100_OK;
 }
 

--- a/src/w5100.c
+++ b/src/w5100.c
@@ -152,6 +152,7 @@ uint16_t w5100_get_rx_size(enum W5100SCH _s) {
  * functions)
  */
 uint16_t w5100_read_rx_rsr(enum W5100SCH _s, uint16_t *_buff) {
+  assert(_buff != NULL);
   // read from 16 bit register MSB first.
   for (int i = 1; i >= 0; i--) {
     w5100_read_byte(W5100_MEMAP_SREG_BASE(_s) + 0x0026 + i,
@@ -171,6 +172,7 @@ uint16_t w5100_read_rx_rsr(enum W5100SCH _s, uint16_t *_buff) {
  * functions)
  */
 uint16_t w5100_read_tx_fsr(enum W5100SCH _s, uint16_t *_buff) {
+  assert(_buff != NULL);
   // read from 16 bit register MSB first.
   for (int i = 1; i >= 0; i--) {
     w5100_read_byte(W5100_MEMAP_SREG_BASE(_s) + 0x0020 + i,
@@ -180,6 +182,7 @@ uint16_t w5100_read_tx_fsr(enum W5100SCH _s, uint16_t *_buff) {
 }
 
 uint16_t w5100_write_bytes(uint16_t addr, const uint8_t *buffer, uint16_t len) {
+  assert(buffer != NULL);
   for (uint16_t i = 0; i < len; i++) {
     w5100_write_byte(addr + i, buffer[i]);
   }
@@ -187,6 +190,7 @@ uint16_t w5100_write_bytes(uint16_t addr, const uint8_t *buffer, uint16_t len) {
 }
 
 uint16_t w5100_read_bytes(uint16_t addr, uint8_t *buffer, uint16_t len) {
+  assert(buffer != NULL);
   for (uint16_t i = 0; i < len; i++) {
     w5100_read_byte(addr + i, buffer + i);
   }

--- a/src/w5100.c
+++ b/src/w5100.c
@@ -101,3 +101,11 @@ w5100_status_t w5100_reset(void) {
   } while (++counter < 20);
   return W5100_ERR;
 }
+
+void w5100_exec_sock_cmd(const enum W5100SockChannel sock,
+                         const enum W5100SockCmds cmd) {
+  w5100_write_sn_cr(sock, cmd);
+  // after command completion SnCR will autoclear
+  while (w5100_read_sn_cr(sock))
+    ;
+}

--- a/src/w5100.c
+++ b/src/w5100.c
@@ -104,6 +104,8 @@ w5100_status_t w5100_configure() {
       smem_map[i].rx_mem.offset = W5100_RX_BUFFER_BASE;
       smem_map[i].tx_mem.offset = W5100_TX_BUFFER_BASE;
     } else {
+      smem_map[i].rx_mem.size = rx_alloc_sizes[i];
+      smem_map[i].tx_mem.size = tx_alloc_sizes[i];
       smem_map[i].rx_mem.offset =
           smem_map[i - 1].rx_mem.offset + smem_map[i - 1].rx_mem.mask + 0x1;
       smem_map[i].tx_mem.offset =

--- a/src/w5100.c
+++ b/src/w5100.c
@@ -52,6 +52,42 @@ void _read_byte(uint16_t addr, uint8_t *buffer) {
   spi_disable_ss();
 }
 
+/**
+ * @brief Custom read function for 16 bit SN_RX_RSR (RX Received Size register).
+ * The datasheet indicates the register must be read starting with the MSB to
+ * the LSB. See section 4.2 RX_RSR.
+ *
+ * @param _s target socket
+ * @param _buff read buffer
+ * @return uint16_t number of bytes read (for consistency with other expanded
+ * functions)
+ */
+uint16_t w5100_read_rx_rsr(enum W5100SCH _s, uint16_t *_buff) {
+  // read from 16 bit register MSB first.
+  for (uint16_t i = 1; i >= 0; i--) {
+    _read_byte(W5100_MEMAP_SREG_BASE(_s) + 0x0026 + i, (uint8_t *)_buff + i);
+  }
+  return 2;
+}
+
+/**
+ * @brief Custom read function for 16 bit SN_TX_FSR (socket tx free size
+ * register). The datasheet indicates the register must be read starting with
+ * the MSB to the LSB. See section 4.2 SN_TX_FSR.
+ *
+ * @param _s target socket
+ * @param _buff read buffer
+ * @return uint16_t number of bytes read (for consistency with other expanded
+ * functions)
+ */
+uint16_t w5100_read_tx_fsr(enum W5100SCH _s, uint16_t *_buff) {
+  // read from 16 bit register MSB first.
+  for (uint16_t i = 1; i >= 0; i--) {
+    _read_byte(W5100_MEMAP_SREG_BASE(_s) + 0x0020 + i, (uint8_t *)_buff + i);
+  }
+  return 2;
+}
+
 uint16_t _write_bytes(uint16_t addr, const uint8_t *buffer, uint16_t len) {
   for (uint16_t i = 0; i < len; i++) {
     _write_byte(addr + i, buffer[i]);

--- a/src/w5100.c
+++ b/src/w5100.c
@@ -29,14 +29,15 @@ static const uint16_t rx_alloc_sizes[4] = {0x800, 0x400, 0x1000, 0x400};
 static const uint16_t tx_alloc_sizes[4] = {0x800, 0x1000, 0x400, 0x400};
 
 // socket memory map for tx and rx buffers
-static w5100_mem_t smem_map[4] = {{.rx_mem = {.mask = 0x0, .offset = 0x0},
-                                   .tx_mem = {.mask = 0x0, .offset = 0x0}},
-                                  {.rx_mem = {.mask = 0x0, .offset = 0x0},
-                                   .tx_mem = {.mask = 0x0, .offset = 0x0}},
-                                  {.rx_mem = {.mask = 0x0, .offset = 0x0},
-                                   .tx_mem = {.mask = 0x0, .offset = 0x0}},
-                                  {.rx_mem = {.mask = 0x0, .offset = 0x0},
-                                   .tx_mem = {.mask = 0x0, .offset = 0x0}}
+static w5100_mem_t smem_map[4] = {
+    {.rx_mem = {.mask = 0x0, .offset = 0x0, .size = 0x0},
+     .tx_mem = {.mask = 0x0, .offset = 0x0, .size = 0x0}},
+    {.rx_mem = {.mask = 0x0, .offset = 0x0, .size = 0x0},
+     .tx_mem = {.mask = 0x0, .offset = 0x0, .size = 0x0}},
+    {.rx_mem = {.mask = 0x0, .offset = 0x0, .size = 0x0},
+     .tx_mem = {.mask = 0x0, .offset = 0x0, .size = 0x0}},
+    {.rx_mem = {.mask = 0x0, .offset = 0x0, .size = 0x0},
+     .tx_mem = {.mask = 0x0, .offset = 0x0, .size = 0x0}}
 
 };
 
@@ -128,6 +129,14 @@ uint16_t w5100_get_tx_mask(enum W5100SCH _s) {
 
 uint16_t w5100_get_rx_mask(enum W5100SCH _s) {
   return smem_map[_s].rx_mem.mask;
+}
+
+uint16_t w5100_get_tx_size(enum W5100SCH _s) {
+  return smem_map[_s].rx_mem.size;
+}
+
+uint16_t w5100_get_rx_size(enum W5100SCH _s) {
+  return smem_map[_s].tx_mem.size;
 }
 
 /**

--- a/src/w5100.c
+++ b/src/w5100.c
@@ -115,7 +115,7 @@ w5100_status_t w5100_configure(w5100_mem_t *sb) {
  */
 uint16_t w5100_read_rx_rsr(enum W5100SCH _s, uint16_t *_buff) {
   // read from 16 bit register MSB first.
-  for (uint16_t i = 1; i >= 0; i--) {
+  for (int i = 1; i >= 0; i--) {
     _read_byte(W5100_MEMAP_SREG_BASE(_s) + 0x0026 + i, (uint8_t *)_buff + i);
   }
   return 2;
@@ -133,7 +133,7 @@ uint16_t w5100_read_rx_rsr(enum W5100SCH _s, uint16_t *_buff) {
  */
 uint16_t w5100_read_tx_fsr(enum W5100SCH _s, uint16_t *_buff) {
   // read from 16 bit register MSB first.
-  for (uint16_t i = 1; i >= 0; i--) {
+  for (int i = 1; i >= 0; i--) {
     _read_byte(W5100_MEMAP_SREG_BASE(_s) + 0x0020 + i, (uint8_t *)_buff + i);
   }
   return 2;


### PR DESCRIPTION
# Description
This PR implements the drivers for the W5100 socket subsystem. Facilitating communication over TCP and UDP is possible using these socket read and write algorithms. Furthermore ethernet phy functions were expanded to include socket configuration and previously unimplemented common register endpoints for the W5100.

> Some of the algorithms were adapted from the open source firmware provided [here](https://github.com/dronectl/Ethernet). The statements where I was unsure of the motivation I left a `REVIEW` tag to notify us that it may be the cause of undefined behaviour.

## Resolutions
 - [x] Implement socket register IO interfaces as functions
 - [x] Define socket subsystem states
 - [x] Implement socket read and write algorithms for the w5100
 - [x] Design and configure socket buffer sizes for each channel
 - [x] Implement basic random number helper using adc noise sampling (suspended)

## Issues
closes #5 