### PR TITLE
Logging Macros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,8 @@ add_executable(
   src/ethernet.c
   src/socket.c
   src/adc.c
+  src/logger.c
+  src/cbuffer.c
 )
 
 # AVR Fuses

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ add_executable(
   src/adc.c
   src/logger.c
   src/cbuffer.c
+  src/usart.c
 )
 
 # AVR Fuses

--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -6,6 +6,8 @@
 #define raptor_VERSION_MINOR @raptor_VERSION_MINOR@
 
 #define F_CPU @F_CPU@
+#define MAX_LOGGING_LINE_LEN @MAX_LOGGING_LINE_LEN@
+#define MAX_CBUFFER_SIZE @MAX_CBUFFER_SIZE@
 // clang-format on
 
 #endif // __CONFIG_H__

--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -7,7 +7,7 @@
 
 #define F_CPU @F_CPU@
 #define MAX_LOGGING_LINE_LEN @MAX_LOGGING_LINE_LEN@
-#define MAX_CBUFFER_SIZE @MAX_CBUFFER_SIZE@
+#define MAX_LOGGING_CBUFFER_SIZE @MAX_LOGGING_CBUFFER_SIZE@
 // clang-format on
 
 #endif // __CONFIG_H__

--- a/include/cbuffer.h
+++ b/include/cbuffer.h
@@ -1,0 +1,37 @@
+/**
+ * @file cbuffer.h
+ * @author ztnel (christian911@sympatico.ca)
+ * @brief A lightweight circular buffer API
+ * @version 0.1
+ * @date 2022-10
+ *
+ * @copyright Copyright © 2022 Christian Sargusingh
+ *
+ */
+
+#ifndef __CBUF_H__
+#define __CBUF_H__
+
+#include <stddef.h>
+#include <stdint.h>
+
+typedef int cbuffer_status_t;
+
+#define CBUFFER_SUCCESS (cbuffer_status_t)0
+#define CBUFFER_ERR (cbuffer_status_t)1
+#define CBUFFER_OVERFLOW (cbuffer_status_t)2
+#define CBUFFER_UNDERFLOW (cbuffer_status_t)3
+
+typedef struct cbuffer_t {
+  void *buffer;      // buffer data
+  size_t size;       // buffer size
+  size_t elem_size;  // element size
+  size_t head;       // head position idx
+  size_t tail;       // tail position idx
+} cbuffer_t;
+
+void cbuffer_init(cbuffer_t *cbuffer, void *buffer, size_t elem_size, size_t size);
+cbuffer_status_t cbuffer_write(cbuffer_t *cbuffer, const void *data);
+void *cbuffer_get(cbuffer_t *cbuffer);
+
+#endif  // __CBUF_H__

--- a/include/cbuffer.h
+++ b/include/cbuffer.h
@@ -23,15 +23,16 @@ typedef int cbuffer_status_t;
 #define CBUFFER_UNDERFLOW (cbuffer_status_t)3
 
 typedef struct cbuffer_t {
-  void *buffer;      // buffer data
-  size_t size;       // buffer size
-  size_t elem_size;  // element size
-  size_t head;       // head position idx
-  size_t tail;       // tail position idx
+  void *buffer;     // buffer data
+  size_t size;      // buffer size
+  size_t elem_size; // element size
+  size_t head;      // head position idx
+  size_t tail;      // tail position idx
 } cbuffer_t;
 
-void cbuffer_init(cbuffer_t *cbuffer, void *buffer, size_t elem_size, size_t size);
+void cbuffer_init(cbuffer_t *cbuffer, void *buffer, size_t elem_size,
+                  size_t size);
 cbuffer_status_t cbuffer_write(cbuffer_t *cbuffer, const void *data);
 void *cbuffer_get(cbuffer_t *cbuffer);
 
-#endif  // __CBUF_H__
+#endif // __CBUF_H__

--- a/include/logger.h
+++ b/include/logger.h
@@ -1,0 +1,65 @@
+/**
+ * @file logger.h
+ * @brief
+ * @version 0.1
+ * @date 2023-01
+ *
+ * @copyright Copyright © 2023 dronectl
+ *
+ */
+
+#ifndef __LOGGER_H__
+#define __LOGGER_H__
+
+#include <stdio.h>
+
+#ifndef MAX_LOGGING_LINE_LEN
+#define MAX_LOGGING_LINE_LEN 100
+#endif
+
+// logging levels
+enum logger_level {
+  LOGGER_TRACE,
+  LOGGER_INFO,
+  LOGGER_WARNING,
+  LOGGER_ERROR,
+  LOGGER_CRITICAL,
+  LOGGER_DISABLE
+};
+
+enum logger_level logger_get_level(void);
+void logger_set_level(enum logger_level level);
+void logger_out(enum logger_level level, const char *func, int line,
+                const char *fmt, ...);
+
+#ifndef critical
+#define critical(...) __CRITICAL(__VA_ARGS__, "")
+#define __CRITICAL(fmt, ...)                                                   \
+  logger_out(LOGGER_CRITICAL, __func__, __LINE__, fmt, __VA_ARGS__)
+#endif
+
+#ifndef error
+#define error(...) __ERROR(__VA_ARGS__, "")
+#define __ERROR(fmt, ...)                                                      \
+  logger_out(LOGGER_ERROR, __func__, __LINE__, fmt, __VA_ARGS__)
+#endif
+
+#ifndef warning
+#define warning(...) __WARNING(__VA_ARGS__, "")
+#define __WARNING(fmt, ...)                                                    \
+  logger_out(LOGGER_WARNING, __func__, __LINE__, fmt, __VA_ARGS__)
+#endif
+
+#ifndef info
+#define info(...) __INFO(__VA_ARGS__, "")
+#define __INFO(fmt, ...)                                                       \
+  logger_out(LOGGER_INFO, __func__, __LINE__, fmt, __VA_ARGS__)
+#endif
+
+#ifndef trace
+#define trace(...) __TRACE(__VA_ARGS__, "")
+#define __TRACE(fmt, ...)                                                      \
+  logger_out(LOGGER_TRACE, __func__, __LINE__, fmt, __VA_ARGS__)
+#endif
+
+#endif // __LOGGER_H__

--- a/include/logger.h
+++ b/include/logger.h
@@ -16,6 +16,13 @@
 #ifndef MAX_LOGGING_LINE_LEN
 #define MAX_LOGGING_LINE_LEN 100
 #endif
+#ifndef MAX_LOGGING_CBUFFER_SIZE
+#define MAX_LOGGING_CBUFFER_SIZE 10
+#endif
+
+#ifndef LOGGING_LEVEL
+#define LOGGING_LEVEL 0
+#endif
 
 // logging levels
 enum logger_level {
@@ -27,10 +34,12 @@ enum logger_level {
   LOGGER_DISABLE
 };
 
+void logger_init(void);
 enum logger_level logger_get_level(void);
 void logger_set_level(enum logger_level level);
 void logger_out(enum logger_level level, const char *func, int line,
                 const char *fmt, ...);
+void logger_flush(void);
 
 #ifndef critical
 #define critical(...) __CRITICAL(__VA_ARGS__, "")

--- a/include/usart.h
+++ b/include/usart.h
@@ -1,0 +1,19 @@
+
+#ifndef __USART_H__
+#define __USART_H__
+
+#include "config.h"
+#include <stdint.h>
+#include <stdio.h>
+
+// Define baud rate
+#define USART_BAUDRATE 115200
+// #define BAUD_PRESCALE (((F_CPU / (USART_BAUDRATE * 16UL))) - 1)
+#define BAUD_PRESCALE (uint16_t)(F_CPU / (16.0 * USART_BAUDRATE) - 0.5)
+
+void usart_init(void);
+void usart_puts(const char *line);
+int usart_putc(char c, FILE *stream);
+char usart_getc(void);
+
+#endif //__USART_H__

--- a/src/cbuffer.c
+++ b/src/cbuffer.c
@@ -1,0 +1,57 @@
+/**
+ * @file cbuffer.c
+ * @author ztnel (christian911@sympatico.ca)
+ * @brief A lightweight circular buffer API
+ * @version 0.1
+ * @date 2022-10
+ *
+ * @copyright Copyright © 2022 Christian Sargusingh
+ *
+ */
+
+#include "cbuffer.h"
+
+#include <assert.h>
+#include <string.h> // memcpy
+
+// NOTE: internal function no null ptr assertions
+static inline uint8_t is_full(cbuffer_t *cb) {
+  return ((cb->head + 1) % cb->size) == cb->tail;
+}
+
+// NOTE: internal function no null ptr assertions
+static inline uint8_t is_empty(cbuffer_t *cb) { return cb->tail == cb->head; }
+
+void cbuffer_init(cbuffer_t *cbuffer, void *buffer, size_t elem_size,
+                  size_t size) {
+  // assert(cbuffer && buffer);
+  cbuffer->head = 0;
+  cbuffer->tail = 0;
+  cbuffer->buffer = buffer;
+  cbuffer->size = size;
+  cbuffer->elem_size = elem_size;
+}
+
+cbuffer_status_t cbuffer_write(cbuffer_t *cbuffer, const void *data) {
+  assert(cbuffer);
+  if (is_full(cbuffer)) {
+    return CBUFFER_OVERFLOW;
+  }
+  size_t index = (cbuffer->head * cbuffer->elem_size) %
+                 (cbuffer->size * cbuffer->elem_size);
+  memcpy((uint8_t *)cbuffer->buffer + index, data, cbuffer->elem_size);
+  cbuffer->head = (cbuffer->head + 1) % cbuffer->size;
+  return CBUFFER_SUCCESS;
+}
+
+void *cbuffer_get(cbuffer_t *cbuffer) {
+  assert(cbuffer);
+  if (is_empty(cbuffer)) {
+    return NULL;
+  }
+  size_t index = (cbuffer->tail * cbuffer->elem_size) %
+                 (cbuffer->size * cbuffer->elem_size);
+  void *ret = (uint8_t *)cbuffer->buffer + index;
+  cbuffer->tail = (cbuffer->tail + 1) % cbuffer->size;
+  return ret;
+}

--- a/src/logger.c
+++ b/src/logger.c
@@ -11,6 +11,7 @@
 #include "cbuffer.h"
 #include <stdarg.h>
 #include <string.h>
+#include <time.h>
 
 // program log level (disable by default)
 static enum logger_level _level = LOGGER_DISABLE;

--- a/src/logger.c
+++ b/src/logger.c
@@ -1,0 +1,85 @@
+/**
+ * @file logger.c
+ * @brief
+ * @version 0.1
+ * @date 2023-01
+ *
+ * @copyright Copyright © 2023 dronectl
+ *
+ */
+#include "logger.h"
+#include "cbuffer.h"
+#include <stdarg.h>
+
+// program log level (disable by default)
+static enum logger_level _level = LOGGER_DISABLE;
+
+static cbuffer_t log_cbuf;
+
+/**
+ * @brief Get the string representation of log level enum
+ *
+ * @param level log level enum
+ * @return char*
+ */
+static char *_get_level_str(enum logger_level level) {
+  switch (level) {
+    case LOGGER_TRACE:
+      return "TRACE";
+    case LOGGER_INFO:
+      return "INFO";
+    case LOGGER_WARNING:
+      return "WARN";
+    case LOGGER_ERROR:
+      return "ERR";
+    default:
+      return "CRIT";
+  }
+}
+
+void logger_init(void) {
+  // initialize cbuffer
+  log_cbuf.elem_size = MAX_CBUFFER_SIZE;
+  log_cbuf.head = 0;
+  log_cbuf.tail = 0;
+}
+
+/**
+ * @brief Set the program log level
+ *
+ * @param level target logging level
+ */
+void logger_set_level(enum logger_level level) { _level = level; }
+
+/**
+ * @brief Get the program log level
+ *
+ * @return enum Level
+ */
+enum logger_level logger_get_level(void) { return _level; }
+
+/**
+ * @brief Perform log filtration and standard log construction parsing variable
+ * arguments
+ *
+ * @param level log level enum
+ * @param func macro expanded log containing function name
+ * @param line macro expanded log line
+ * @param fmt log string formatter
+ * @param ... variable arguments for string formatter
+ */
+void logger_out(const enum logger_level level, const char *func, const int line,
+                const char *fmt, ...) {
+  char buffer[MAX_LOGGING_LINE_LEN];
+  va_list args;
+  // filter output by log level
+  if (logger_get_level() > level) {
+    return;
+  }
+  sprintf(buffer, "[%s]\t %s:%i ", _get_level_str(level), func, line);
+  va_start(args, fmt);
+  usart_println(buffer);
+  vsprintf(buffer, fmt, args);
+  va_end(args);
+  printf(buffer);
+}

--- a/src/main.c
+++ b/src/main.c
@@ -9,8 +9,10 @@
  *
  */
 
-#include "ethernet.h"
+// #include "ethernet.h"
+#include "logger.h"
 #include "spi.h"
+#include "usart.h"
 #include "utils.h"
 #include <avr/cpufunc.h>
 #include <avr/io.h>
@@ -23,34 +25,43 @@ static void spinlock(void) {
   DDRB = (1 << DDB5);
   // sync nop
   _NOP();
+  critical("Entering spinlock.");
   while (1) {
+    logger_flush();
     // blink SCK
     PORTB ^= (1 << PORTB5);
     delay_cycles(100000);
+    info("info log test");
+    trace("trace log test");
+    warning("warning log test");
+    error("error log test");
+    critical("critical log test");
   }
 }
 
 int main(void) {
+  usart_init();
+  logger_init();
   // initialize phy
-  ethernet_phy_init();
-  ipv4_address_t gw;
-  gw.bytes[0] = 192;
-  gw.bytes[1] = 168;
-  gw.bytes[2] = 2;
-  gw.bytes[3] = 1;
-  ipv4_address_t mask;
-  mask.bytes[0] = 255;
-  mask.bytes[1] = 255;
-  mask.bytes[2] = 0;
-  mask.bytes[3] = 0;
-  ipv4_address_t ip_addr;
-  ip_addr.bytes[0] = 0;
-  ip_addr.bytes[1] = 0;
-  ip_addr.bytes[2] = 0;
-  ip_addr.bytes[3] = 0;
-  enet_config_t configuration = {
-      .gateway = gw, .subnet_mask = mask, .ip_addr = ip_addr};
-  ethernet_configure(&configuration);
+  // ethernet_phy_init();
+  // ipv4_address_t gw;
+  // gw.bytes[0] = 192;
+  // gw.bytes[1] = 168;
+  // gw.bytes[2] = 2;
+  // gw.bytes[3] = 1;
+  // ipv4_address_t mask;
+  // mask.bytes[0] = 255;
+  // mask.bytes[1] = 255;
+  // mask.bytes[2] = 0;
+  // mask.bytes[3] = 0;
+  // ipv4_address_t ip_addr;
+  // ip_addr.bytes[0] = 0;
+  // ip_addr.bytes[1] = 0;
+  // ip_addr.bytes[2] = 0;
+  // ip_addr.bytes[3] = 0;
+  // enet_config_t configuration = {
+  //     .gateway = gw, .subnet_mask = mask, .ip_addr = ip_addr};
+  // ethernet_configure(&configuration);
   spinlock();
   return 0;
 }

--- a/src/usart.c
+++ b/src/usart.c
@@ -1,0 +1,56 @@
+
+#include "usart.h"
+
+#include <avr/interrupt.h>
+#include <avr/io.h>
+#include <string.h>
+
+static FILE usartout = FDEV_SETUP_STREAM(usart_putc, NULL, _FDEV_SETUP_WRITE);
+
+/**
+ * @brief Print a line of characters to USART channel
+ *
+ * @param line character array to print
+ */
+void usart_puts(const char *line) {
+  for (size_t i = 0; i < strlen(line); i++) {
+    usart_putc(line[i], stdout);
+  }
+}
+
+void usart_init(void) {
+  stdout = &usartout;
+  /* Load upper 8-bits into the high byte of the UBRR register
+      Default frame format is 8 data bits, no parity, 1 stop bit
+      to change use UCSRC, see AVR datasheet */
+  cli();
+  // Enable receiver and transmitter and receive complete interrupt
+  UCSR0B = (1 << TXEN0) | (1 << RXEN0) | (0 << UCSZ01) |
+           (1 << RXCIE0); //|(1<<TXCIE1);
+  // 8-bit data, 1 stop bit, Aynchronous USART, no parity
+  UCSR0C = (1 << UCSZ01) | (1 << UCSZ00) | (0 << USBS0) | (0 << UMSEL01) |
+           (0 << UMSEL00) | (0 << UPM01) | (0 << UPM00);
+  UBRR0H = (uint8_t)(BAUD_PRESCALE >> 8);
+  UBRR0L = (uint8_t)(BAUD_PRESCALE); // Load lower 8-bits into the low byte of
+                                     // the UBRR register
+  sei();
+}
+
+int usart_putc(char c, FILE *stream) {
+  if (c == '\n') {
+    usart_putc('\r', stream);
+  }
+  // wait until buffer is ready to receive new data
+  while ((UCSR0A & (1 << UDRE0)) == 0)
+    ;
+  // write to USART data register TXD
+  UDR0 = c;
+  return 0;
+}
+
+char usart_getc(void) {
+  while ((UCSR0A & (1 << RXC0)) == 0)
+    ;
+  // read from USART data register RXD
+  return UDR0;
+}


### PR DESCRIPTION
# Description
This PR implements logging macros and a basic logging subsystem for managing log aggregation and filtering by log level. I also included a basic USART driver to aid with testing. The USART module binds stdout to its `putc` method to configure calls to `printf` to pipe out to the USART subsystem. 

## Usage
The logger subsystem uses a circular buffer to store log lines and provides a `logger_flush` function for flushing all logs to `stdout`. This improves write efficiency especially for a system which will have a complex set of FSMs.
```c
#include "logger.h"
#include "usart.h"

int main(void) {
  // initialize stdout interface and logging buffer
  usart_init();
  logger_init();
  // write out logging messages
  info("info log test");
  trace("trace log test");
  warning("warning log test");
  error("error log test");
  critical("critical log test");
  // flushes buffer to stdout
  logger_flush();
}
```
After flashing the board and connecting to the UART port at 115200 baud:
```
screen /dev/tty.usbserial-A6024AOD 115200
```
This will yield some logging outputs similar to below:
```
[  INFO ] spinlock:34   info log test
[ TRACE ] spinlock:35   trace log test
[  WARN ] spinlock:36   warning log test
[   ERR ] spinlock:37   error log test
[  CRIT ] spinlock:38   critical log tes
...
```

## Resolutions
 - [x] Implemented a basic USART driver
 - [x] Implemented logging macros and log level handling
 - [x] Implemented a universal circular buffer and applied in logging subsystem

## Issues
closes #14 
closes #7 
