### PR TITLE
BME280 Driver and HAL I2C Clock Fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ add_executable(
   src/freertos_openocd.c
   src/stm32h7xx_it.c
   src/stm32h7xx_hal_msp.c
+  src/stm32h7xx_hal_timebase_tim.c
   src/startup_stm32h723zgtx.s
   src/system_stm32h7xx.c
   ${STM32CUBEH7_SRC}/Drivers/BSP/Components/lan8742/lan8742.c

--- a/include/FreeRTOSConfig.h
+++ b/include/FreeRTOSConfig.h
@@ -154,16 +154,6 @@ header file. */
 standard names. */
 #define vPortSVCHandler SVC_Handler
 #define xPortPendSVHandler PendSV_Handler
-
-// Debugging definitions
-#ifdef RAPTOR_DEBUG
-#define configGENERATE_RUN_TIME_STATS 1
-#define configUSE_STATS_FORMATTING_FUNCTIONS 1
-extern void vconfigure_rtos_stats_timer(void);
-extern uint32_t vget_runtime_count(void);
-#define portCONFIGURE_TIMER_FOR_RUN_TIME_STATS() vconfigure_rtos_stats_timer()
-#define portGET_RUN_TIME_COUNTER_VALUE() vget_runtime_count()
-#endif // RAPTOR_DEBUG
 #define configRECORD_STACK_HIGH_ADDRESS 1
 
 #endif /* FREERTOS_CONFIG_H */

--- a/include/bme280.h
+++ b/include/bme280.h
@@ -68,6 +68,7 @@ typedef int bme280_status_t;
 #define BME280_ERR (bme280_status_t)1
 #define BME280_VERIFICATION (bme280_status_t)2
 #define BME280_TIMEOUT (bme280_status_t)3
+#define BME280_NVM_COPY (bme280_status_t)4
 
 /**
  * @brief Oversampling register settings
@@ -171,7 +172,7 @@ typedef struct bme280_dev_t {
 bme280_status_t bme280_init(bme280_dev_t *dev);
 
 /**
- * @brief Hardware reset
+ * @brief Sensor soft reset
  *
  * @param dev bme280 device struct
  * @return bme280_status_t status code

--- a/include/bme280.h
+++ b/include/bme280.h
@@ -68,7 +68,9 @@ typedef int bme280_status_t;
 #define BME280_ERR (bme280_status_t)1
 #define BME280_VERIFICATION (bme280_status_t)2
 #define BME280_TIMEOUT (bme280_status_t)3
-#define BME280_NVM_COPY (bme280_status_t)4
+#define BME280_NVM_ERR (bme280_status_t)4
+#define BME280_FORCE_ERR (bme280_status_t)5
+#define BME280_MEAS_TIMEOUT (bme280_status_t)6
 
 /**
  * @brief Oversampling register settings
@@ -164,7 +166,7 @@ typedef struct bme280_dev_t {
 } bme280_dev_t;
 
 /**
- * @brief Initialize, verify, load calibration trimming parameters, enable measurement subsystems.
+ * @brief Verify sensor, reset, load calibration trimming parameters, enable measurement subsystems.
  *
  * @param dev bme280 device struct
  * @return bme280_status_t status code
@@ -188,12 +190,12 @@ bme280_status_t bme280_reset(bme280_dev_t *dev);
 bme280_status_t bme280_sleep(bme280_dev_t *dev);
 
 /**
- * @brief Bulk read of temperature, humidity, and pressure in standard units (˚C, % and Pa respectively)
+ * @brief Perform a triggered bulk read of temperature, humidity, and pressure using forced mode.
  *
  * @param dev bme280 device struct
  * @param measurements measurement payload struct
  * @return bme280_status_t status code
  */
-bme280_status_t bme280_read(bme280_dev_t *dev, bme280_meas_t *measurements);
+bme280_status_t bme280_trigger_read(bme280_dev_t *dev, bme280_meas_t *measurements);
 
 #endif // __BME280_H__

--- a/src/health.c
+++ b/src/health.c
@@ -60,7 +60,7 @@ static enum HealthState fsm_tick(const enum HealthState state) {
     case HEALTH_READ: {
       // read from alive sensors
       bme280_meas_t bme280_meas = {.humidity = 0.0f, .humidity_raw = 0, .pressure = 0.0f, .pressure_raw = 0, .temperature = 0.0f, .temperature_raw = 0};
-      bme280_read(&bme280, &bme280_meas);
+      bme280_trigger_read(&bme280, &bme280_meas);
       health_report.humidity = bme280_meas.humidity;
       health_report.pressure = bme280_meas.pressure;
       health_report.temperature = bme280_meas.temperature;

--- a/src/health.c
+++ b/src/health.c
@@ -10,6 +10,7 @@ static health_report_t health_report;
 
 // devices
 bme280_dev_t bme280;
+static bme280_meas_t bme280_meas;
 
 #ifndef RAPTOR_DEBUG
 static IWDG_HandleTypeDef iwdg_handle;
@@ -59,7 +60,6 @@ static enum HealthState fsm_tick(const enum HealthState state) {
       break;
     case HEALTH_READ: {
       // read from alive sensors
-      bme280_meas_t bme280_meas = {.humidity = 0.0f, .humidity_raw = 0, .pressure = 0.0f, .pressure_raw = 0, .temperature = 0.0f, .temperature_raw = 0};
       bme280_trigger_read(&bme280, &bme280_meas);
       health_report.humidity = bme280_meas.humidity;
       health_report.pressure = bme280_meas.pressure;

--- a/src/stm32h7xx_hal_timebase_tim.c
+++ b/src/stm32h7xx_hal_timebase_tim.c
@@ -1,0 +1,160 @@
+/**
+  ******************************************************************************
+  * @file    stm32h7xx_hal_timebase_tim.c
+  * @author  MCD Application Team
+  * @brief   HAL time base based on the hardware TIM.
+  *
+  *          This file overrides the native HAL time base functions (defined as weak)
+  *          the TIM time base:
+  *           + Initializes the TIM peripheral generate a Period elapsed Event each 1ms
+  *           + HAL_IncTick is called inside HAL_TIM_PeriodElapsedCallback ie each 1ms
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2017 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
+  @verbatim
+  ==============================================================================
+                        ##### How to use this driver #####
+  ==============================================================================
+    [..]
+    This file must be copied to the application folder and modified as follows:
+    (#) Rename it to 'stm32h7xx_hal_timebase_tim.c'
+    (#) Add this file and the TIM HAL drivers to your project and uncomment
+       HAL_TIM_MODULE_ENABLED define in stm32h7xx_hal_conf.h
+
+  @endverbatim
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32h7xx_hal.h"
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+static TIM_HandleTypeDef TimHandle;
+/* Private function prototypes -----------------------------------------------*/
+void TIM6_DAC_IRQHandler(void);
+/* Private functions ---------------------------------------------------------*/
+
+/**
+ * @brief  This function configures the TIM6 as a time base source.
+ *         The time source is configured to have 1ms time base with a dedicated
+ *         Tick interrupt priority.
+ * @note   This function is called  automatically at the beginning of program after
+ *         reset by HAL_Init() or at any time when clock is configured, by HAL_RCC_ClockConfig().
+ * @param  TickPriority Tick interrupt priority.
+ * @retval HAL status
+ */
+HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
+  RCC_ClkInitTypeDef clkconfig;
+  uint32_t uwTimclock, uwAPB1Prescaler;
+  uint32_t uwPrescalerValue;
+  uint32_t pFLatency;
+
+  /*Configure the TIM6 IRQ priority */
+  if (TickPriority < (1UL << __NVIC_PRIO_BITS)) {
+    HAL_NVIC_SetPriority(TIM6_DAC_IRQn, TickPriority, 0U);
+
+    /* Enable the TIM6 global Interrupt */
+    HAL_NVIC_EnableIRQ(TIM6_DAC_IRQn);
+    uwTickPrio = TickPriority;
+  } else {
+    return HAL_ERROR;
+  }
+
+  /* Enable TIM6 clock */
+  __HAL_RCC_TIM6_CLK_ENABLE();
+
+  /* Get clock configuration */
+  HAL_RCC_GetClockConfig(&clkconfig, &pFLatency);
+
+  /* Get APB1 prescaler */
+  uwAPB1Prescaler = clkconfig.APB1CLKDivider;
+
+  /* Compute TIM6 clock */
+  if (uwAPB1Prescaler == RCC_HCLK_DIV1) {
+    uwTimclock = HAL_RCC_GetPCLK1Freq();
+  } else {
+    uwTimclock = 2UL * HAL_RCC_GetPCLK1Freq();
+  }
+
+  /* Compute the prescaler value to have TIM6 counter clock equal to 1MHz */
+  uwPrescalerValue = (uint32_t)((uwTimclock / 1000000U) - 1U);
+
+  /* Initialize TIM6 */
+  TimHandle.Instance = TIM6;
+
+  /* Initialize TIMx peripheral as follow:
+  + Period = [(TIM6CLK/1000) - 1]. to have a (1/1000) s time base.
+  + Prescaler = (uwTimclock/1000000 - 1) to have a 1MHz counter clock.
+  + ClockDivision = 0
+  + Counter direction = Up
+  */
+  TimHandle.Init.Period = (1000000U / 1000U) - 1U;
+  TimHandle.Init.Prescaler = uwPrescalerValue;
+  TimHandle.Init.ClockDivision = 0;
+  TimHandle.Init.CounterMode = TIM_COUNTERMODE_UP;
+  if (HAL_TIM_Base_Init(&TimHandle) == HAL_OK) {
+    /* Start the TIM time Base generation in interrupt mode */
+    return HAL_TIM_Base_Start_IT(&TimHandle);
+  }
+
+  /* Return function status */
+  return HAL_ERROR;
+}
+
+/**
+ * @brief  Suspend Tick increment.
+ * @note   Disable the tick increment by disabling TIM6 update interrupt.
+ * @param  None
+ * @retval None
+ */
+void HAL_SuspendTick(void) {
+  /* Disable TIM6 update Interrupt */
+  __HAL_TIM_DISABLE_IT(&TimHandle, TIM_IT_UPDATE);
+}
+
+/**
+ * @brief  Resume Tick increment.
+ * @note   Enable the tick increment by Enabling TIM6 update interrupt.
+ * @param  None
+ * @retval None
+ */
+void HAL_ResumeTick(void) {
+  /* Enable TIM6 Update interrupt */
+  __HAL_TIM_ENABLE_IT(&TimHandle, TIM_IT_UPDATE);
+}
+
+/**
+ * @brief  Period elapsed callback in non blocking mode
+ * @note   This function is called  when TIM6 interrupt took place, inside
+ * HAL_TIM_IRQHandler(). It makes a direct call to HAL_IncTick() to increment
+ * a global variable "uwTick" used as application time base.
+ * @param  htim TIM handle
+ * @retval None
+ */
+void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim) {
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(htim);
+
+  HAL_IncTick();
+}
+
+/**
+ * @brief  This function handles TIM interrupt request.
+ * @param  None
+ * @retval None
+ */
+void TIM6_DAC_IRQHandler(void) {
+  HAL_TIM_IRQHandler(&TimHandle);
+}

--- a/src/stm32h7xx_it.c
+++ b/src/stm32h7xx_it.c
@@ -21,15 +21,6 @@
 #include "FreeRTOS.h"
 #include "stm32h7xx_hal.h"
 
-/* Private typedef -----------------------------------------------------------*/
-/* Private define ------------------------------------------------------------*/
-/* Private macro -------------------------------------------------------------*/
-/* Private variables ---------------------------------------------------------*/
-extern ETH_HandleTypeDef EthHandle;
-/* Private function prototypes -----------------------------------------------*/
-void ETH_IRQHandler(void);
-/* Private functions ---------------------------------------------------------*/
-
 /******************************************************************************/
 /*            Cortex-M7 Processor Exceptions Handlers                         */
 /******************************************************************************/
@@ -98,26 +89,3 @@ void DebugMon_Handler(void) {}
 /*  available peripheral interrupt handler's name please refer to the startup */
 /*  file (startup_stm32h7xx.s).                                               */
 /******************************************************************************/
-/**
- * @brief  This function handles Ethernet interrupt request.
- * @param  None
- * @retval None
- */
-void ETH_IRQHandler(void) { HAL_ETH_IRQHandler(&EthHandle); }
-
-/**
- * @brief  This function handles SysTick Handler.
- * @param  None
- * @retval None
- */
-void SysTick_Handler(void) {
-  HAL_IncTick();
-}
-
-/**
- * @}
- */
-
-/**
- * @}
- */

--- a/tests/bme280/main.c
+++ b/tests/bme280/main.c
@@ -447,7 +447,7 @@ int main(void) {
   bme280.i2c = hi2c2;
   bme280_init(&bme280);
   while (1) {
-    bme280_read(&bme280, &meas);
-    HAL_Delay(100);
+    bme280_trigger_read(&bme280, &meas);
+    HAL_Delay(1000);
   }
 }


### PR DESCRIPTION
# Description
This PR addresses failures in calibration loads from the BME280 sensor. The reason for the calibration load failure was because the sensor was still loading trimming parameters from its non-volatile memory (NVM) storage into its I2C assessable registers. When the device is soft reset it takes 2ms to boot up (as per general electrical specifications Table 1) then performs a reload of its trimming parameters from NVM. the status register contains a status bit for tracking the completion of its load from NVM. We need to wait for the status bit to clear before reading out the trimming parameters. The new implementation of the reset function performs the necessary backoffs and status checks to ensure the device is ready to read out its trimming values.

Furthermore this PR adds boiler plate generated by CubeMX to address the clock configuration for the HAL library. This includes the `system32h7xx_hal_timebase_tim.c` which implements:
1.  Initializes the TIM peripheral generate a period elapsed event each 1ms
2. `HAL_IncTick` is called inside `HAL_TIM_PeriodElapsedCallback` ie each 1ms

## Resolutions
 - [x] Fixed #35  by adding backoff and polling for the IM_UPDATE bit in the status register on sensor reset.
 - [x] Fixed #36 which addresses the HAL clock configuration in the context of the FreeRTOS runtime.

## Issues
closes #35 
closes #36 