### PR TITLE
DBC Assertion Implementation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(
   drivers/ethernet/ethernetif.c
   drivers/bme280.c
   drivers/pwm.c
+  common/uassert.c
   common/cbuffer.c
   common/logger.c
   common/sysreg.c

--- a/src/common/uassert.c
+++ b/src/common/uassert.c
@@ -1,0 +1,18 @@
+
+#include "uassert.h"
+
+struct assert_trace g_assert_info = {0};
+
+void assert_handler(const uint32_t line, const uint32_t *pc, const uint32_t *lr) {
+  // File and line deliberately left empty
+  g_assert_info.line = line;
+  g_assert_info.pc = (uint32_t)pc;
+  g_assert_info.lr = (uint32_t)lr;
+#ifdef RAPTOR_DEBUG
+  // halt CPU core for easier debugging
+  __asm("bkpt 5");
+#else
+  // spinlock and wait for hardware watchdog to trigger reset
+  while (1);
+#endif
+}

--- a/src/common/uassert.h
+++ b/src/common/uassert.h
@@ -1,0 +1,45 @@
+/**
+ * @file uassert.c
+ * @author ztnel (christian911@sympatico.ca)
+ * @brief Micro-assert: Assertion tracing for minimal memory footprint
+ * @version 0.1
+ * @date 2024-11
+ *
+ * @copyright Copyright © 2024 Christian Sargusingh
+ *
+ */
+
+#ifndef __UASSERT_H__
+#define __UASSERT_H__
+
+#include <stdint.h>
+
+struct assert_trace {
+  uint32_t pc;   // program counter register
+  uint32_t lr;   // link register
+  uint32_t line; // line number (for avoiding compiler optimzations where asserts could be merged)
+};
+
+extern struct assert_trace g_assert_info;
+
+extern void assert_handler(const uint32_t line, const uint32_t *pc, const uint32_t *lr);
+
+#define GET_LR() __builtin_return_address(0)
+#define GET_PC(_a) __asm volatile("mov %0, pc" : "=r"(_a))
+
+#define ASSERT_RECORD(__LINE__)       \
+  do {                                \
+    void *pc;                         \
+    GET_PC(pc);                       \
+    const void *lr = GET_LR();        \
+    assert_handler(__LINE__, pc, lr); \
+  } while (0)
+
+#define ASSERT(exp)            \
+  do {                         \
+    if (!(exp)) {              \
+      ASSERT_RECORD(__LINE__); \
+    }                          \
+  } while (0)
+
+#endif // __UASSERT_H__


### PR DESCRIPTION
# Description
Implemented a small assertion library which allows tracing assertion failures without the need to store variable length strings for filenames etc. The assertion saves the PC and LR registers into a global assert tracing struct for inspection. For debug builds the assert halts the cpu with `bkpt` to allow developers to inspect the tracing struct while the CPU is halted. In release builds we enter a spin lock to allow the hardware watchdog to reset the CPU.

> We will need a way to save the trace variables to NVM so it can be reported on next boot.

## Issues
closes #68 